### PR TITLE
Use Schema instead of Type for base

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -177,9 +177,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": true,
       "type": "object",

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -177,9 +177,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -162,9 +162,7 @@
       },
       "type": "array"
     },
-    "raw": {
-      "additionalProperties": true
-    }
+    "raw": true
   },
   "additionalProperties": false,
   "type": "object",

--- a/fixtures/fully_qualified.json
+++ b/fixtures/fully_qualified.json
@@ -177,9 +177,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -170,9 +170,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/no_ref_qual_types.json
+++ b/fixtures/no_ref_qual_types.json
@@ -169,9 +169,7 @@
       },
       "type": "array"
     },
-    "raw": {
-      "additionalProperties": true
-    }
+    "raw": true 
   },
   "additionalProperties": false,
   "type": "object",
@@ -376,9 +374,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -169,9 +169,7 @@
       },
       "type": "array"
     },
-    "raw": {
-      "additionalProperties": true
-    }
+    "raw": true
   },
   "additionalProperties": false,
   "type": "object",
@@ -376,9 +374,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -177,9 +177,7 @@
           },
           "type": "array"
         },
-        "raw": {
-          "additionalProperties": true
-        }
+        "raw": true
       },
       "additionalProperties": false,
       "type": "object",

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -110,8 +110,8 @@ type CustomTypeFieldWithInterface struct {
 	CreatedAt CustomTimeWithInterface
 }
 
-func (CustomTimeWithInterface) JSONSchemaType() *Type {
-	return &Type{
+func (CustomTimeWithInterface) JSONSchema() *Schema {
+	return &Schema{
 		Type:   "string",
 		Format: "date-time",
 	}
@@ -165,8 +165,8 @@ type CompactDate struct {
 	Month int
 }
 
-func (CompactDate) JSONSchemaType() *Type {
-	return &Type{
+func (CompactDate) JSONSchema() *Schema {
+	return &Schema{
 		Type:        "string",
 		Title:       "Compact Date",
 		Description: "Short date that only includes year and month",
@@ -202,13 +202,13 @@ type CustomSliceOuter struct {
 
 type CustomSliceType []string
 
-func (CustomSliceType) JSONSchemaType() *Type {
-	return &Type{
-		OneOf: []*Type{{
+func (CustomSliceType) JSONSchema() *Schema {
+	return &Schema{
+		OneOf: []*Schema{{
 			Type: "string",
 		}, {
 			Type: "array",
-			Items: &Type{
+			Items: &Schema{
 				Type: "string",
 			},
 		}},
@@ -217,17 +217,17 @@ func (CustomSliceType) JSONSchemaType() *Type {
 
 type CustomMapType map[string]string
 
-func (CustomMapType) JSONSchemaType() *Type {
+func (CustomMapType) JSONSchema() *Schema {
 	properties := orderedmap.New()
-	properties.Set("key", &Type{
+	properties.Set("key", &Schema{
 		Type: "string",
 	})
-	properties.Set("value", &Type{
+	properties.Set("value", &Schema{
 		Type: "string",
 	})
-	return &Type{
+	return &Schema{
 		Type: "array",
-		Items: &Type{
+		Items: &Schema{
 			Type:       "object",
 			Properties: properties,
 			Required:   []string{"key", "value"},
@@ -255,9 +255,9 @@ func TestSchemaGeneration(t *testing.T) {
 		{&TestUser{}, &Reflector{FullyQualifyTypeNames: true}, "fixtures/fully_qualified.json"},
 		{&TestUser{}, &Reflector{DoNotReference: true, FullyQualifyTypeNames: true}, "fixtures/no_ref_qual_types.json"},
 		{&CustomTypeField{}, &Reflector{
-			TypeMapper: func(i reflect.Type) *Type {
+			Mapper: func(i reflect.Type) *Schema {
 				if i == reflect.TypeOf(CustomTime{}) {
-					return &Type{
+					return &Schema{
 						Type:   "string",
 						Format: "date-time",
 					}
@@ -326,5 +326,5 @@ func TestBaselineUnmarshal(t *testing.T) {
 	actualJSON, _ := json.MarshalIndent(actualSchema, "", "  ")
 	// _ = ioutil.WriteFile("fixtures/defaults.out.json", actualJSON, 0644)
 
-	require.Equal(t, strings.ReplaceAll(string(expectedJSON), `\/`, "/"), string(actualJSON))
+	require.JSONEq(t, string(expectedJSON), string(actualJSON))
 }


### PR DESCRIPTION
General refactor to use `Schema` instead of `Type` as a base for all operations. This keeps the library vocabulary more in line with the JSON Schema documentation.

To support this, the Unmarshal and Marshal JSON methods were updated to support boolean input/output which means that properties without a defined schema (like json.RawMessage types) can just be defined with `raw: true`, which is valid JSON Schema. This also simplifies the use of `addtionalProperties`.