### PR TITLE
Support Schema ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This package can be used to generate [JSON Schemas](http://json-schema.org/lates
 - Supports simple string and numeric enums.
 - Supports custom property fields via the `jsonschema_extras` struct tag.
 
-This repository is a fork of the original [jsonschema](https://github.com/alecthomas/jsonschema) by [@alecthomas](https://github.com/alecthomas). At [Invopop](https://invopop.com) we use jsonschema as a cornerstone in our [GOBL library](https://github.com/invopop/gobl), and wanted to be able to continue building and adding features without taking up Alec's time.
+This repository is a fork of the original [jsonschema](https://github.com/alecthomas/jsonschema) by [@alecthomas](https://github.com/alecthomas). At [Invopop](https://invopop.com) we use jsonschema as a cornerstone in our [GOBL library](https://github.com/invopop/gobl), and wanted to be able to continue building and adding features without taking up Alec's time. There have been a few significant changes that probably mean this version is a not compatible with with Alec's:
+
+- The original was stuck on the draft-04 version of JSON Schema, we've now moved to the latest JSON Schema Draft 2020-12.
+- Schema IDs are added automatically from the current Go package's URL in order to be unique, and can be disabled with the `Anonymous` option.
+- Support for the `FullyQualifyTypeName` option has been removed. If you have conflicts, you should use multiple schema files with different IDs, set the `DoNotReference` option to true to hide definitions completely, or add your own naming strategy using the `Namer` property.
 
 ## Example
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -26,6 +26,7 @@ func ExampleReflect() {
 	// Output:
 	// {
 	//   "$schema": "http://json-schema.org/draft/2020-12/schema",
+	//   "$id": "https://github.com/invopop/jsonschema_test/sample-user",
 	//   "$ref": "#/$defs/SampleUser",
 	//   "$defs": {
 	//     "SampleUser": {

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
   "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
@@ -22,7 +23,6 @@
           "type": "integer"
         },
         "grand": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
           "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {

--- a/fixtures/compact_date.json
+++ b/fixtures/compact_date.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/compact-date",
   "$ref": "#/$defs/CompactDate",
   "$defs": {
     "CompactDate": {

--- a/fixtures/custom_additional.json
+++ b/fixtures/custom_additional.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/grandfather-type",
   "$ref": "#/$defs/GrandfatherType",
   "$defs": {
     "GrandfatherType": {

--- a/fixtures/custom_base_schema_id.json
+++ b/fixtures/custom_base_schema_id.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "http://example.com/schema/TestUser",
   "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
@@ -23,7 +24,6 @@
           "type": "integer"
         },
         "grand": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
           "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {

--- a/fixtures/custom_map_type.json
+++ b/fixtures/custom_map_type.json
@@ -1,37 +1,37 @@
 {
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
-	"$ref": "#/$defs/CustomMapOuter",
-	"$defs": {
-	  "CustomMapOuter": {
-		"properties": {
-		  "my_map": {
-			"$schema": "http://json-schema.org/draft/2020-12/schema",
-			"$ref": "#/$defs/CustomMapType"
-		  }
-		},
-		"additionalProperties": false,
-		"type": "object",
-		"required": [
-		  "my_map"
-		]
-	  },
-	  "CustomMapType": {
-		"items": {
-		  "properties": {
-			"key": {
-			  "type": "string"
-			},
-			"value": {
-			  "type": "string"
-			}
-		  },
-		  "type": "object",
-		  "required": [
-			"key",
-			"value"
-		  ]
-		},
-		"type": "array"
-	  }
-	}
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/custom-map-outer",
+  "$ref": "#/$defs/CustomMapOuter",
+  "$defs": {
+    "CustomMapOuter": {
+      "properties": {
+        "my_map": {
+          "$ref": "#/$defs/CustomMapType"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "my_map"
+      ]
+    },
+    "CustomMapType": {
+      "items": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key",
+          "value"
+        ]
+      },
+      "type": "array"
+    }
   }
+}

--- a/fixtures/custom_slice_type.json
+++ b/fixtures/custom_slice_type.json
@@ -1,32 +1,32 @@
 {
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
-	"$ref": "#/$defs/CustomSliceOuter",
-	"$defs": {
-	  "CustomSliceOuter": {
-		"properties": {
-		  "slice": {
-			"$schema": "http://json-schema.org/draft/2020-12/schema",
-			"$ref": "#/$defs/CustomSliceType"
-		  }
-		},
-		"additionalProperties": false,
-		"type": "object",
-		"required": [
-		  "slice"
-		]
-	  },
-	  "CustomSliceType": {
-		"oneOf": [
-		  {
-			"type": "string"
-		  },
-		  {
-			"items": {
-			  "type": "string"
-			},
-			"type": "array"
-		  }
-		]
-	  }
-	}
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/custom-slice-outer",
+  "$ref": "#/$defs/CustomSliceOuter",
+  "$defs": {
+    "CustomSliceOuter": {
+      "properties": {
+        "slice": {
+          "$ref": "#/$defs/CustomSliceType"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "slice"
+      ]
+    },
+    "CustomSliceType": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ]
+    }
   }
+}

--- a/fixtures/custom_type.json
+++ b/fixtures/custom_type.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/custom-type-field",
   "$ref": "#/$defs/CustomTypeField",
   "$defs": {
     "CustomTypeField": {

--- a/fixtures/custom_type_with_interface.json
+++ b/fixtures/custom_type_with_interface.json
@@ -1,23 +1,23 @@
 {
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
-	"$ref": "#/$defs/CustomTypeFieldWithInterface",
-	"$defs": {
-	  "CustomTimeWithInterface": {
-		"type": "string",
-		"format": "date-time"
-	  },
-	  "CustomTypeFieldWithInterface": {
-		"properties": {
-		  "CreatedAt": {
-			"$schema": "http://json-schema.org/draft/2020-12/schema",
-			"$ref": "#/$defs/CustomTimeWithInterface"
-		  }
-		},
-		"additionalProperties": false,
-		"type": "object",
-		"required": [
-		  "CreatedAt"
-		]
-	  }
-	}
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/custom-type-field-with-interface",
+  "$ref": "#/$defs/CustomTypeFieldWithInterface",
+  "$defs": {
+    "CustomTimeWithInterface": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "CustomTypeFieldWithInterface": {
+      "properties": {
+        "CreatedAt": {
+          "$ref": "#/$defs/CustomTimeWithInterface"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "CreatedAt"
+      ]
+    }
   }
+}

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -1,5 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$defs": {
+    "GrandfatherType": {
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
+    }
+  },
   "properties": {
     "some_base_property": {
       "type": "integer"
@@ -8,7 +23,6 @@
       "type": "integer"
     },
     "grand": {
-      "$schema": "http://json-schema.org/draft/2020-12/schema",
       "$ref": "#/$defs/GrandfatherType"
     },
     "SomeUntaggedBaseProperty": {
@@ -186,19 +200,5 @@
     "color",
     "roles",
     "raw"
-  ],
-  "$defs": {
-    "GrandfatherType": {
-      "properties": {
-        "family_name": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "family_name"
-      ]
-    }
-  }
+  ]
 }

--- a/fixtures/disable_inlining_embedded_anchored.json
+++ b/fixtures/disable_inlining_embedded_anchored.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/invopop/jsonschema/outer",
+  "$anchor": "Outer",
   "properties": {
     "inner": {
+      "$anchor": "Inner",
       "properties": {
         "foo": {
           "type": "string"

--- a/fixtures/go_comments.json
+++ b/fixtures/go_comments.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/examples/user",
   "$ref": "#/$defs/User",
   "$defs": {
     "Pet": {
@@ -62,7 +63,6 @@
         },
         "pets": {
           "items": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
             "$ref": "#/$defs/Pet"
           },
           "type": "array",
@@ -70,7 +70,6 @@
         },
         "plants": {
           "items": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
             "$ref": "#/$defs/Plant"
           },
           "type": "array",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -4,16 +4,9 @@
   "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
-      "properties": {
-        "family_name": {
-          "type": "string"
-        }
-      },
+      "properties": {},
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "family_name"
-      ]
+      "type": "object"
     },
     "TestUser": {
       "properties": {

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -1,11 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
   "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
-      "properties": {},
-      "additionalProperties": true,
-      "type": "object"
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
     },
     "TestUser": {
       "properties": {
@@ -16,7 +24,6 @@
           "type": "integer"
         },
         "grand": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
           "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$anchor": "TestUser",
   "properties": {
     "some_base_property": {
       "type": "integer"
@@ -9,6 +10,7 @@
       "type": "integer"
     },
     "grand": {
+      "$anchor": "GrandfatherType",
       "properties": {
         "family_name": {
           "type": "string"

--- a/fixtures/nullable.json
+++ b/fixtures/nullable.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-nullable",
   "$ref": "#/$defs/TestNullable",
   "$defs": {
     "TestNullable": {

--- a/fixtures/oneof.json
+++ b/fixtures/oneof.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/root-one-of",
   "$ref": "#/$defs/RootOneOf",
   "$defs": {
     "ChildOneOf": {
@@ -80,7 +81,6 @@
           "type": "string"
         },
         "child": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
           "$ref": "#/$defs/ChildOneOf"
         }
       },

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
   "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
@@ -23,7 +24,6 @@
           "type": "integer"
         },
         "grand": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
           "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {

--- a/fixtures/schema_with_minimum.json
+++ b/fixtures/schema_with_minimum.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/min-value",
   "$ref": "#/$defs/MinValue",
   "$defs": {
     "MinValue": {

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -1,201 +1,9 @@
 {
-  "properties": {
-    "some_base_property": {
-      "type": "integer"
-    },
-    "some_base_property_yaml": {
-      "type": "integer"
-    },
-    "grand": {
-      "properties": {
-        "family_name": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "family_name"
-      ]
-    },
-    "SomeUntaggedBaseProperty": {
-      "type": "boolean"
-    },
-    "PublicNonExported": {
-      "type": "integer"
-    },
-    "id": {
-      "type": "integer"
-    },
-    "name": {
-      "type": "string",
-      "maxLength": 20,
-      "minLength": 1,
-      "pattern": ".*",
-      "title": "the name",
-      "description": "this is a property",
-      "default": "alex",
-      "readOnly": true,
-      "examples": [
-        "joe",
-        "lucy"
-      ]
-    },
-    "password": {
-      "type": "string",
-      "writeOnly": true
-    },
-    "friends": {
-      "items": {
-        "type": "integer"
-      },
-      "type": "array",
-      "description": "list of IDs, omitted when empty"
-    },
-    "tags": {
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "options": {
-      "type": "object"
-    },
-    "TestFlag": {
-      "type": "boolean"
-    },
-    "birth_date": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "website": {
-      "type": "string",
-      "format": "uri"
-    },
-    "network_address": {
-      "type": "string",
-      "format": "ipv4"
-    },
-    "photo": {
-      "type": "string",
-      "contentEncoding": "base64"
-    },
-    "photo2": {
-      "type": "string",
-      "contentEncoding": "base64"
-    },
-    "feeling": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "integer"
-        }
-      ]
-    },
-    "age": {
-      "type": "integer",
-      "maximum": 120,
-      "exclusiveMaximum": true,
-      "minimum": 18,
-      "exclusiveMinimum": true
-    },
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "Baz": {
-      "type": "string",
-      "foo": [
-        "bar",
-        "bar1"
-      ],
-      "hello": "world"
-    },
-    "color": {
-      "type": "string",
-      "enum": [
-        "red",
-        "green",
-        "blue"
-      ]
-    },
-    "rank": {
-      "type": "integer",
-      "enum": [
-        1,
-        2,
-        3
-      ]
-    },
-    "mult": {
-      "type": "number",
-      "enum": [
-        1,
-        1.5,
-        2
-      ]
-    },
-    "roles": {
-      "items": {
-        "type": "string",
-        "enum": [
-          "admin",
-          "moderator",
-          "user"
-        ]
-      },
-      "type": "array"
-    },
-    "priorities": {
-      "items": {
-        "type": "integer",
-        "enum": [
-          -1,
-          0,
-          1
-        ]
-      },
-      "type": "array"
-    },
-    "offsets": {
-      "items": {
-        "type": "number",
-        "enum": [
-          1.570796,
-          3.141592,
-          6.283185
-        ]
-      },
-      "type": "array"
-    },
-    "anything": true,
-    "raw": true 
-  },
-  "additionalProperties": false,
-  "type": "object",
-  "required": [
-    "some_base_property",
-    "some_base_property_yaml",
-    "grand",
-    "SomeUntaggedBaseProperty",
-    "PublicNonExported",
-    "id",
-    "name",
-    "password",
-    "TestFlag",
-    "age",
-    "email",
-    "Baz",
-    "color",
-    "roles",
-    "raw"
-  ],
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$ref": "#/$defs/TestUser",
   "$defs": {
-    "github.com/invopop/jsonschema.GrandfatherType": {
+    "GrandfatherType": {
       "properties": {
         "family_name": {
           "type": "string"
@@ -207,7 +15,7 @@
         "family_name"
       ]
     },
-    "github.com/invopop/jsonschema.TestUser": {
+    "TestUser": {
       "properties": {
         "some_base_property": {
           "type": "integer"
@@ -216,16 +24,7 @@
           "type": "integer"
         },
         "grand": {
-          "properties": {
-            "family_name": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "family_name"
-          ]
+          "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
-  "$ref": "#/$defs/github.com/invopop/jsonschema.TestUser",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$ref": "#TestUser",
   "$defs": {
-    "github.com/invopop/jsonschema.GrandfatherType": {
+    "GrandfatherType": {
+      "$anchor": "GrandfatherType",
       "properties": {
         "family_name": {
           "type": "string"
@@ -14,7 +16,8 @@
         "family_name"
       ]
     },
-    "github.com/invopop/jsonschema.TestUser": {
+    "TestUser": {
+      "$anchor": "TestUser",
       "properties": {
         "some_base_property": {
           "type": "integer"
@@ -23,8 +26,7 @@
           "type": "integer"
         },
         "grand": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
-          "$ref": "#/$defs/github.com/invopop/jsonschema.GrandfatherType"
+          "$ref": "#GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"

--- a/fixtures/test_yaml_and_json.json
+++ b/fixtures/test_yaml_and_json.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-yaml-and-json",
   "$ref": "#/$defs/TestYamlAndJson",
   "$defs": {
     "TestYamlAndJson": {

--- a/fixtures/test_yaml_and_json_prefer_yaml.json
+++ b/fixtures/test_yaml_and_json_prefer_yaml.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-yaml-and-json",
   "$ref": "#/$defs/TestYamlAndJson",
   "$defs": {
     "TestYamlAndJson": {

--- a/fixtures/user_with_anchor.json
+++ b/fixtures/user_with_anchor.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/user-with-anchor",
+  "$ref": "#/$defs/UserWithAnchor",
+  "$defs": {
+    "UserWithAnchor": {
+      "properties": {
+        "name": {
+          "$anchor": "Name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/fixtures/yaml_inline_embed.json
+++ b/fixtures/yaml_inline_embed.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-yaml-inline",
   "$ref": "#/$defs/TestYamlInline",
   "$defs": {
     "TestYamlInline": {

--- a/id.go
+++ b/id.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -16,7 +17,7 @@ type ID string
 func (id ID) Validate() error {
 	u, err := url.Parse(id.String())
 	if err != nil {
-		return errors.New("invalid URL")
+		return fmt.Errorf("invalid URL: %w", err)
 	}
 	if u.Hostname() == "" {
 		return errors.New("missing hostname")
@@ -33,7 +34,7 @@ func (id ID) Validate() error {
 	return nil
 }
 
-// Anchor either adds or replaces the anchor part of the schema URI.
+// Anchor sets the anchor part of the schema URI.
 func (id ID) Anchor(name string) ID {
 	b := id.Base()
 	return ID(b.String() + "#" + name)

--- a/id.go
+++ b/id.go
@@ -1,0 +1,45 @@
+package jsonschema
+
+import "strings"
+
+// ID represents a Schema ID type which should always be a URI.
+// See draft-bhutton-json-schema-00 section 8.2.1
+type ID string
+
+// Anchor either adds or replaces the anchor part of the schema URI.
+func (id ID) Anchor(name string) ID {
+	b := id.Base()
+	return ID(b.String() + "#" + name)
+}
+
+// Def adds or replaces a definition identifier.
+func (id ID) Def(name string) ID {
+	b := id.Base()
+	return ID(b.String() + "#/$defs/" + name)
+}
+
+// Add appends the provided path to the id, and removes any
+// anchor data that might be there.
+func (id ID) Add(path string) ID {
+	b := id.Base()
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return ID(b.String() + path)
+}
+
+// Base removes any anchor information from the schema
+func (id ID) Base() ID {
+	s := id.String()
+	i := strings.LastIndex(s, "#")
+	if i != -1 {
+		s = s[0:i]
+	}
+	s = strings.TrimRight(s, "/")
+	return ID(s)
+}
+
+// String provides string version of ID
+func (id ID) String() string {
+	return string(id)
+}

--- a/id.go
+++ b/id.go
@@ -1,10 +1,37 @@
 package jsonschema
 
-import "strings"
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
 
 // ID represents a Schema ID type which should always be a URI.
 // See draft-bhutton-json-schema-00 section 8.2.1
 type ID string
+
+// Validate is used to check if the ID looks like a proper schema.
+// This is done by parsing the ID as a URL and checking it has all the
+// relevant parts.
+func (id ID) Validate() error {
+	u, err := url.Parse(id.String())
+	if err != nil {
+		return errors.New("invalid URL")
+	}
+	if u.Hostname() == "" {
+		return errors.New("missing hostname")
+	}
+	if !strings.Contains(u.Hostname(), ".") {
+		return errors.New("hostname does not look valid")
+	}
+	if u.Path == "" {
+		return errors.New("path is expected")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return errors.New("unexpected schema")
+	}
+	return nil
+}
 
 // Anchor either adds or replaces the anchor part of the schema URI.
 func (id ID) Anchor(name string) ID {

--- a/id_test.go
+++ b/id_test.go
@@ -25,3 +25,33 @@ func TestID(t *testing.T) {
 	id = id.Def("Name")
 	assert.EqualValues(t, base+"/user#/$defs/Name", id)
 }
+
+func TestIDValidation(t *testing.T) {
+	id := jsonschema.ID("https://invopop.com/schema/user")
+	assert.NoError(t, id.Validate())
+
+	id = "https://encoding/json"
+	if assert.Error(t, id.Validate()) {
+		assert.Contains(t, id.Validate().Error(), "hostname does not look valid")
+	}
+
+	id = "time"
+	if assert.Error(t, id.Validate()) {
+		assert.Contains(t, id.Validate().Error(), "hostname")
+	}
+
+	id = "http://invopop.com"
+	if assert.Error(t, id.Validate()) {
+		assert.Contains(t, id.Validate().Error(), "path")
+	}
+
+	id = "foor://invopop.com/schema/user"
+	if assert.Error(t, id.Validate()) {
+		assert.Contains(t, id.Validate().Error(), "schema")
+	}
+
+	id = "invopop.com\n/test"
+	if assert.Error(t, id.Validate()) {
+		assert.Contains(t, id.Validate().Error(), "invalid URL")
+	}
+}

--- a/id_test.go
+++ b/id_test.go
@@ -1,0 +1,27 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestID(t *testing.T) {
+	base := "https://invopop.com/schema"
+	id := jsonschema.ID(base)
+
+	assert.Equal(t, base, id.String())
+
+	id = id.Add("user")
+	assert.EqualValues(t, base+"/user", id)
+
+	id = id.Anchor("Name")
+	assert.EqualValues(t, base+"/user#Name", id)
+
+	id = id.Anchor("Title")
+	assert.EqualValues(t, base+"/user#Title", id)
+
+	id = id.Def("Name")
+	assert.EqualValues(t, base+"/user#/$defs/Name", id)
+}

--- a/reflect.go
+++ b/reflect.go
@@ -445,8 +445,8 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type) *Sche
 	}
 
 	ignored := false
-	for _, ignored := range r.IgnoredTypes {
-		if reflect.TypeOf(ignored) == t {
+	for _, it := range r.IgnoredTypes {
+		if reflect.TypeOf(it) == t {
 			ignored = true
 			break
 		}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -270,7 +270,6 @@ func TestReflectFromType(t *testing.T) {
 	}{
 		Test: "foo",
 	}
-	//x := time.Now()
 	typ = reflect.TypeOf(x)
 	s = r.Reflect(typ)
 	assert.Empty(t, s.ID)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -336,6 +336,7 @@ func TestBaselineUnmarshal(t *testing.T) {
 }
 
 func compareSchemaOutput(t *testing.T, f string, r *Reflector, obj interface{}) {
+	t.Helper()
 	expectedJSON, err := ioutil.ReadFile(f)
 	require.NoError(t, err)
 
@@ -343,12 +344,12 @@ func compareSchemaOutput(t *testing.T, f string, r *Reflector, obj interface{}) 
 	actualJSON, _ := json.MarshalIndent(actualSchema, "", "  ")
 
 	if *updateFixtures {
-		_ = ioutil.WriteFile(f, actualJSON, 0644)
+		_ = ioutil.WriteFile(f, actualJSON, 0600)
 	}
 
 	if !assert.JSONEq(t, string(expectedJSON), string(actualJSON)) {
 		if *compareFixtures {
-			_ = ioutil.WriteFile(strings.TrimSuffix(f, ".json")+".out.json", actualJSON, 0644)
+			_ = ioutil.WriteFile(strings.TrimSuffix(f, ".json")+".out.json", actualJSON, 0600)
 		}
 	}
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -172,6 +172,10 @@ type CompactDate struct {
 	Month int
 }
 
+type UserWithAnchor struct {
+	Name string `json:"name" jsonschema:"anchor=Name"`
+}
+
 func (CompactDate) JSONSchema() *Schema {
 	return &Schema{
 		Type:        "string",
@@ -260,6 +264,7 @@ func TestSchemaGeneration(t *testing.T) {
 		fixture   string
 	}{
 		{&TestUser{}, &Reflector{}, "fixtures/test_user.json"},
+		{&UserWithAnchor{}, &Reflector{}, "fixtures/user_with_anchor.json"},
 		{&TestUser{}, &Reflector{AssignAnchor: true}, "fixtures/test_user_assign_anchor.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 		{&TestUser{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"flag"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -15,8 +16,12 @@ import (
 
 	"github.com/invopop/jsonschema/examples"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var updateFixtures = flag.Bool("update", false, "set to update fixtures")
+var compareFixtures = flag.Bool("compare", false, "output failed fixtures with .out.json")
 
 type GrandfatherType struct {
 	FamilyName string `json:"family_name" jsonschema:"required"`
@@ -241,21 +246,28 @@ type CustomMapOuter struct {
 	MyMap CustomMapType `json:"my_map"`
 }
 
+func TestReflector(t *testing.T) {
+	r := new(Reflector)
+	s := "http://example.com/schema"
+	r.SetBaseSchemaID(s)
+	assert.EqualValues(t, s, r.BaseSchemaID)
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
 		reflector *Reflector
 		fixture   string
 	}{
-		{&RootOneOf{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/oneof.json"},
-		{&TestUser{}, &Reflector{}, "fixtures/defaults.json"},
+		{&TestUser{}, &Reflector{}, "fixtures/test_user.json"},
+		{&TestUser{}, &Reflector{AssignAnchor: true}, "fixtures/test_user_assign_anchor.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 		{&TestUser{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},
 		{&TestUser{}, &Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json"},
 		{&TestUser{}, &Reflector{IgnoredTypes: []interface{}{GrandfatherType{}}}, "fixtures/ignore_type.json"},
 		{&TestUser{}, &Reflector{DoNotReference: true}, "fixtures/no_reference.json"},
-		{&TestUser{}, &Reflector{FullyQualifyTypeNames: true}, "fixtures/fully_qualified.json"},
-		{&TestUser{}, &Reflector{DoNotReference: true, FullyQualifyTypeNames: true}, "fixtures/no_ref_qual_types.json"},
+		{&TestUser{}, &Reflector{DoNotReference: true, AssignAnchor: true}, "fixtures/no_reference_anchor.json"},
+		{&RootOneOf{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/oneof.json"},
 		{&CustomTypeField{}, &Reflector{
 			Mapper: func(i reflect.Type) *Schema {
 				if i == reflect.TypeOf(CustomTime{}) {
@@ -267,8 +279,8 @@ func TestSchemaGeneration(t *testing.T) {
 				return nil
 			},
 		}, "fixtures/custom_type.json"},
-		{&TestUser{}, &Reflector{DoNotReference: true, FullyQualifyTypeNames: true}, "fixtures/no_ref_qual_types.json"},
 		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true}, "fixtures/disable_inlining_embedded.json"},
+		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true, AssignAnchor: true}, "fixtures/disable_inlining_embedded_anchored.json"},
 		{&MinValue{}, &Reflector{}, "fixtures/schema_with_minimum.json"},
 		{&TestNullable{}, &Reflector{}, "fixtures/nullable.json"},
 		{&TestYamlInline{}, &Reflector{YAMLEmbeddedStructs: true}, "fixtures/yaml_inline_embed.json"},
@@ -298,14 +310,9 @@ func TestSchemaGeneration(t *testing.T) {
 	for _, tt := range tests {
 		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
 		t.Run(name, func(t *testing.T) {
-			f, err := ioutil.ReadFile(tt.fixture)
-			require.NoError(t, err)
-
-			actualSchema := tt.reflector.Reflect(tt.typ)
-			actualJSON, _ := json.MarshalIndent(actualSchema, "", "  ")
-
-			// _ = ioutil.WriteFile(strings.TrimSuffix(tt.fixture, ".json")+".out.json", actualJSON, 0644)
-			require.JSONEq(t, string(f), string(actualJSON))
+			compareSchemaOutput(t,
+				tt.fixture, tt.reflector, tt.typ,
+			)
 		})
 	}
 }
@@ -319,14 +326,24 @@ func prepareCommentReflector(t *testing.T) *Reflector {
 }
 
 func TestBaselineUnmarshal(t *testing.T) {
-	expectedJSON, err := ioutil.ReadFile("fixtures/defaults.json")
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/test_user.json", r, &TestUser{})
+}
+
+func compareSchemaOutput(t *testing.T, f string, r *Reflector, obj interface{}) {
+	expectedJSON, err := ioutil.ReadFile(f)
 	require.NoError(t, err)
 
-	reflector := &Reflector{}
-	actualSchema := reflector.Reflect(&TestUser{})
-
+	actualSchema := r.Reflect(obj)
 	actualJSON, _ := json.MarshalIndent(actualSchema, "", "  ")
-	// _ = ioutil.WriteFile("fixtures/defaults.out.json", actualJSON, 0644)
 
-	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+	if *updateFixtures {
+		_ = ioutil.WriteFile(f, actualJSON, 0644)
+	}
+
+	if !assert.JSONEq(t, string(expectedJSON), string(actualJSON)) {
+		if *compareFixtures {
+			_ = ioutil.WriteFile(strings.TrimSuffix(f, ".json")+".out.json", actualJSON, 0644)
+		}
+	}
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -257,6 +257,25 @@ func TestReflector(t *testing.T) {
 	assert.EqualValues(t, s, r.BaseSchemaID)
 }
 
+func TestReflectFromType(t *testing.T) {
+	r := new(Reflector)
+	tu := new(TestUser)
+	typ := reflect.TypeOf(tu)
+
+	s := r.ReflectFromType(typ)
+	assert.EqualValues(t, "https://github.com/invopop/jsonschema/test-user", s.ID)
+
+	x := struct {
+		Test string
+	}{
+		Test: "foo",
+	}
+	//x := time.Now()
+	typ = reflect.TypeOf(x)
+	s = r.Reflect(typ)
+	assert.Empty(t, s.ID)
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,18 @@
+package jsonschema
+
+import (
+	"regexp"
+	"strings"
+)
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+// ToSnakeCase converts the provided string into snake case using dashes.
+// This is useful for Schema IDs and definitions to be coherent with
+// common JSON Schema examples.
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}-${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}-${2}")
+	return strings.ToLower(snake)
+}


### PR DESCRIPTION
Schema IDs are now supported.

Includes some refactoring for better code re-use, especially with the `ExpandedStruct` reflector option.

Also included is support for auto-assigning the `$anchor` property based on the type's name. 