### PR TITLE
Schema ID Lookup Support

### DIFF
--- a/fixtures/base_schema_id.json
+++ b/fixtures/base_schema_id.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/lookup-user",
+  "$ref": "#/$defs/LookupUser",
+  "$defs": {
+    "LookupName": {
+      "properties": {
+        "first": {
+          "type": "string"
+        },
+        "surname": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "first",
+        "surname"
+      ]
+    },
+    "LookupUser": {
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/LookupName"
+        },
+        "alias": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/fixtures/lookup.json
+++ b/fixtures/lookup.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/lookup-user",
+  "$ref": "#/$defs/LookupUser",
+  "$defs": {
+    "LookupUser": {
+      "properties": {
+        "name": {
+          "$ref": "https://example.com/schemas/lookup-name"
+        },
+        "alias": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/fixtures/lookup_expanded.json
+++ b/fixtures/lookup_expanded.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/lookup-user",
+  "$anchor": "LookupUser",
+  "properties": {
+    "name": {
+      "$ref": "https://example.com/schemas/lookup-name"
+    },
+    "alias": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "name"
+  ]
+}

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/invopop/jsonschema/test-user",
-  "$ref": "#TestUser",
+  "$ref": "#/$defs/TestUser",
   "$defs": {
     "GrandfatherType": {
       "$anchor": "GrandfatherType",
@@ -26,7 +26,7 @@
           "type": "integer"
         },
         "grand": {
-          "$ref": "#GrandfatherType"
+          "$ref": "#/$defs/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"

--- a/id.go
+++ b/id.go
@@ -10,6 +10,9 @@ import (
 // See draft-bhutton-json-schema-00 section 8.2.1
 type ID string
 
+// EmptyID is used to explicitly define an ID with no value.
+const EmptyID ID = ""
+
 // Validate is used to check if the ID looks like a proper schema.
 // This is done by parsing the ID as a URL and checking it has all the
 // relevant parts.

--- a/reflect.go
+++ b/reflect.go
@@ -191,6 +191,11 @@ type Reflector struct {
 	// switching to just allowing additional properties instead.
 	IgnoredTypes []interface{}
 
+	// Lookup allows a function to be defined that will provide a custom mapping of
+	// types to Schema IDs. This allows existing schema documents to be referenced
+	// by their ID instead of being embedded into the current schema definitions.
+	Lookup func(reflect.Type) ID
+
 	// Mapper is a function that can be used to map custom Go types to jsonschema schemas.
 	Mapper func(reflect.Type) *Schema
 
@@ -230,10 +235,11 @@ func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 	}
 
 	name := r.typeName(t)
-	definitions := Definitions{}
 
 	s := new(Schema)
-	bs := r.reflectTypeToSchema(definitions, t)
+	definitions := Definitions{}
+	s.Definitions = definitions
+	bs := r.reflectTypeToSchemaWithID(definitions, t)
 	if r.ExpandedStruct {
 		*s = *definitions[name]
 		delete(definitions, name)
@@ -244,14 +250,14 @@ func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 	// Attempt to set the schema ID
 	if !r.Anonymous {
 		baseSchemaID := r.BaseSchemaID
-		if baseSchemaID == "" {
+		if baseSchemaID == EmptyID {
 			id := ID("https://" + t.PkgPath())
 			if err := id.Validate(); err == nil {
 				// it's okay to silently ignore URL errors
 				baseSchemaID = id
 			}
 		}
-		if baseSchemaID != "" {
+		if baseSchemaID != EmptyID {
 			s.ID = baseSchemaID.Add(ToSnakeCase(name))
 		}
 	}
@@ -296,12 +302,38 @@ func (r *Reflector) SetBaseSchemaID(id string) {
 	r.BaseSchemaID = ID(id)
 }
 
-func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Schema {
+func (r *Reflector) refOrReflectTypeToSchema(definitions Definitions, t reflect.Type) *Schema {
+	if r.Lookup != nil {
+		id := r.Lookup(t)
+		if id != EmptyID {
+			return &Schema{
+				Ref: id.String(),
+			}
+		}
+	}
+
 	// Already added to definitions?
 	if _, ok := definitions[r.typeName(t)]; ok && !r.DoNotReference {
 		return r.refDefinition(definitions, t)
 	}
 
+	return r.reflectTypeToSchemaWithID(definitions, t)
+}
+
+func (r *Reflector) reflectTypeToSchemaWithID(defs Definitions, t reflect.Type) *Schema {
+	s := r.reflectTypeToSchema(defs, t)
+	if s != nil {
+		if r.Lookup != nil {
+			id := r.Lookup(t)
+			if id != EmptyID {
+				s.ID = id
+			}
+		}
+	}
+	return s
+}
+
+func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Schema {
 	if r.Mapper != nil {
 		if t := r.Mapper(t); t != nil {
 			return t
@@ -346,7 +378,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 			rt := &Schema{
 				Type: "object",
 				PatternProperties: map[string]*Schema{
-					"^[0-9]+$": r.reflectTypeToSchema(definitions, t.Elem()),
+					"^[0-9]+$": r.refOrReflectTypeToSchema(definitions, t.Elem()),
 				},
 				AdditionalProperties: FalseSchema,
 			}
@@ -362,7 +394,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 			rt = &Schema{
 				Type: "object",
 				PatternProperties: map[string]*Schema{
-					".*": r.reflectTypeToSchema(definitions, t.Elem()),
+					".*": r.refOrReflectTypeToSchema(definitions, t.Elem()),
 				},
 			}
 		}
@@ -384,7 +416,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 			return returnType
 		}
 		returnType.Type = "array"
-		returnType.Items = r.reflectTypeToSchema(definitions, t.Elem())
+		returnType.Items = r.refOrReflectTypeToSchema(definitions, t.Elem())
 		return returnType
 
 	case reflect.Interface:
@@ -404,7 +436,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		return &Schema{Type: "string"}
 
 	case reflect.Ptr:
-		return r.reflectTypeToSchema(definitions, t.Elem())
+		return r.refOrReflectTypeToSchema(definitions, t.Elem())
 	}
 	panic("unsupported type " + t.String())
 }
@@ -493,7 +525,7 @@ func (r *Reflector) reflectStructFields(st *Schema, definitions Definitions, t r
 			return
 		}
 
-		property := r.reflectTypeToSchema(definitions, f.Type)
+		property := r.refOrReflectTypeToSchema(definitions, f.Type)
 		property.structKeywordsFromTags(f, st, name)
 		if property.Description == "" {
 			property.Description = r.lookupComment(t, f.Name)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -207,6 +207,16 @@ func (TestYamlAndJson2) GetFieldDocString(fieldName string) string {
 	}
 }
 
+type LookupName struct {
+	Given   string `json:"first"`
+	Surname string `json:"surname"`
+}
+
+type LookupUser struct {
+	Name  *LookupName `json:"name"`
+	Alias string      `json:"alias,omitempty"`
+}
+
 type CustomSliceOuter struct {
 	Slice CustomSliceType `json:"slice"`
 }
@@ -302,6 +312,33 @@ func TestSchemaGeneration(t *testing.T) {
 				return nil
 			},
 		}, "fixtures/custom_type.json"},
+		{LookupUser{}, &Reflector{BaseSchemaID: "https://example.com/schemas"}, "fixtures/base_schema_id.json"},
+		{LookupUser{}, &Reflector{
+			BaseSchemaID: "https://example.com/schemas",
+			Lookup: func(i reflect.Type) ID {
+				switch i {
+				case reflect.TypeOf(LookupUser{}):
+					return ID("https://example.com/schemas/lookup-user")
+				case reflect.TypeOf(LookupName{}):
+					return ID("https://example.com/schemas/lookup-name")
+				}
+				return EmptyID
+			},
+		}, "fixtures/lookup.json"},
+		{LookupUser{}, &Reflector{
+			BaseSchemaID:   "https://example.com/schemas",
+			ExpandedStruct: true,
+			AssignAnchor:   true,
+			Lookup: func(i reflect.Type) ID {
+				switch i {
+				case reflect.TypeOf(LookupUser{}):
+					return ID("https://example.com/schemas/lookup-user")
+				case reflect.TypeOf(LookupName{}):
+					return ID("https://example.com/schemas/lookup-name")
+				}
+				return EmptyID
+			},
+		}, "fixtures/lookup_expanded.json"},
 		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true}, "fixtures/disable_inlining_embedded.json"},
 		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true, AssignAnchor: true}, "fixtures/disable_inlining_embedded_anchored.json"},
 		{&MinValue{}, &Reflector{}, "fixtures/schema_with_minimum.json"},

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -325,7 +325,7 @@ func TestSchemaGeneration(t *testing.T) {
 				return EmptyID
 			},
 		}, "fixtures/lookup.json"},
-		{LookupUser{}, &Reflector{
+		{&LookupUser{}, &Reflector{
 			BaseSchemaID:   "https://example.com/schemas",
 			ExpandedStruct: true,
 			AssignAnchor:   true,


### PR DESCRIPTION
This PR enables support for defining a `Lookup` function in the Reflector that will be called to check if the type already has a schema generated elsewhere and should reference it using the `$ref` property.

With this change, complex schemas with multiple files can be generated easily so long as all the schemas have been indexed first.