### PR TITLE
Do not replace ID of root if already set

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -249,7 +249,7 @@ func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 	}
 
 	// Attempt to set the schema ID
-	if !r.Anonymous {
+	if !r.Anonymous && s.ID == EmptyID {
 		baseSchemaID := r.BaseSchemaID
 		if baseSchemaID == EmptyID {
 			id := ID("https://" + t.PkgPath())

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -314,7 +314,6 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/custom_type.json"},
 		{LookupUser{}, &Reflector{BaseSchemaID: "https://example.com/schemas"}, "fixtures/base_schema_id.json"},
 		{LookupUser{}, &Reflector{
-			BaseSchemaID: "https://example.com/schemas",
 			Lookup: func(i reflect.Type) ID {
 				switch i {
 				case reflect.TypeOf(LookupUser{}):


### PR DESCRIPTION
Quick change to fix a bug that would ignore a predefined schema ID lookup for a root element.