### PR TITLE
Embed Value Types

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -31,6 +31,9 @@
         "PublicNonExported": {
           "type": "integer"
         },
+        "MapType": {
+          "type": "object"
+        },
         "id": {
           "type": "integer"
         },
@@ -201,6 +204,7 @@
         "grand",
         "SomeUntaggedBaseProperty",
         "PublicNonExported",
+        "MapType",
         "id",
         "name",
         "password",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -31,6 +31,9 @@
     "PublicNonExported": {
       "type": "integer"
     },
+    "MapType": {
+      "type": "object"
+    },
     "id": {
       "type": "integer"
     },
@@ -202,6 +205,7 @@
     "grand",
     "SomeUntaggedBaseProperty",
     "PublicNonExported",
+    "MapType",
     "id",
     "name",
     "password",

--- a/fixtures/disable_inlining_embedded_anchored.json
+++ b/fixtures/disable_inlining_embedded_anchored.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/invopop/jsonschema/outer",
   "$anchor": "Outer",
   "properties": {
-    "inner": {
+    "Inner": {
       "$anchor": "Inner",
       "properties": {
         "foo": {
@@ -20,6 +20,6 @@
   "additionalProperties": false,
   "type": "object",
   "required": [
-    "inner"
+    "Inner"
   ]
 }

--- a/fixtures/embed_value_type.json
+++ b/fixtures/embed_value_type.json
@@ -1,23 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/invopop/jsonschema/outer",
-  "properties": {
-    "Inner": {
+  "$id": "https://github.com/invopop/jsonschema/embed-value-type-test",
+  "$ref": "#/$defs/EmbedValueTypeTest",
+  "$defs": {
+    "EmbedValueTypeTest": {
       "properties": {
-        "foo": {
+        "CustomStringType": {
           "type": "string"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "foo"
+        "CustomStringType"
       ]
     }
-  },
-  "additionalProperties": false,
-  "type": "object",
-  "required": [
-    "Inner"
-  ]
+  }
 }

--- a/fixtures/embed_value_type.json
+++ b/fixtures/embed_value_type.json
@@ -7,12 +7,16 @@
       "properties": {
         "CustomStringType": {
           "type": "string"
+        },
+        "map_field": {
+          "type": "object"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "CustomStringType"
+        "CustomStringType",
+        "map_field"
       ]
     }
   }

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -25,6 +25,9 @@
         "PublicNonExported": {
           "type": "integer"
         },
+        "MapType": {
+          "type": "object"
+        },
         "id": {
           "type": "integer"
         },
@@ -196,6 +199,7 @@
         "grand",
         "SomeUntaggedBaseProperty",
         "PublicNonExported",
+        "MapType",
         "id",
         "name",
         "password",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -26,6 +26,9 @@
     "PublicNonExported": {
       "type": "integer"
     },
+    "MapType": {
+      "type": "object"
+    },
     "id": {
       "type": "integer"
     },
@@ -197,6 +200,7 @@
     "grand",
     "SomeUntaggedBaseProperty",
     "PublicNonExported",
+    "MapType",
     "id",
     "name",
     "password",

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -28,6 +28,9 @@
     "PublicNonExported": {
       "type": "integer"
     },
+    "MapType": {
+      "type": "object"
+    },
     "id": {
       "type": "integer"
     },
@@ -199,6 +202,7 @@
     "grand",
     "SomeUntaggedBaseProperty",
     "PublicNonExported",
+    "MapType",
     "id",
     "name",
     "password",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -32,6 +32,9 @@
         "PublicNonExported": {
           "type": "integer"
         },
+        "MapType": {
+          "type": "object"
+        },
         "id": {
           "type": "integer"
         },

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -32,6 +32,9 @@
         "PublicNonExported": {
           "type": "integer"
         },
+        "MapType": {
+          "type": "object"
+        },
         "id": {
           "type": "integer"
         },
@@ -203,6 +206,7 @@
         "grand",
         "SomeUntaggedBaseProperty",
         "PublicNonExported",
+        "MapType",
         "id",
         "name",
         "password",

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -34,6 +34,9 @@
         "PublicNonExported": {
           "type": "integer"
         },
+        "MapType": {
+          "type": "object"
+        },
         "id": {
           "type": "integer"
         },
@@ -205,6 +208,7 @@
         "grand",
         "SomeUntaggedBaseProperty",
         "PublicNonExported",
+        "MapType",
         "id",
         "name",
         "password",

--- a/reflect.go
+++ b/reflect.go
@@ -951,11 +951,9 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 
 	// field anonymous but without json tag should be inherited by current type
 	if f.Anonymous && !exist {
-		if !r.YAMLEmbeddedStructs {
+		if !r.YAMLEmbeddedStructs && f.Type.Kind() == reflect.Struct {
 			name = ""
 			embed = true
-		} else {
-			name = strings.ToLower(name)
 		}
 	}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -287,6 +287,12 @@ type KeyNamed struct {
 	RenamedByComputation int `jsonschema_description:"Description was preserved"`
 }
 
+type CustomStringType string
+
+type EmbedValueTypeTest struct {
+	CustomStringType
+}
+
 func TestReflector(t *testing.T) {
 	r := new(Reflector)
 	s := "http://example.com/schema"
@@ -416,6 +422,7 @@ func TestSchemaGeneration(t *testing.T) {
 				return "unknown case"
 			},
 		}, "fixtures/keynamed.json"},
+		{&EmbedValueTypeTest{}, &Reflector{}, "fixtures/embed_value_type.json"},
 	}
 
 	for _, tt := range tests {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -291,6 +291,7 @@ type CustomStringType string
 
 type EmbedValueTypeTest struct {
 	CustomStringType
+	MapType `json:"map_field"`
 }
 
 func TestReflector(t *testing.T) {


### PR DESCRIPTION
Adds support for using embedded non-struct type fields.

Example:

```go
type CustomStringType string

type EmbedValueTypeTest struct {
	CustomStringType
}
```

Output for `EmbedValueTypeTest`:

```json
{
  "$schema": "http://json-schema.org/draft/2020-12/schema",
  "$id": "https://github.com/invopop/jsonschema/embed-value-type-test",
  "$ref": "#/$defs/EmbedValueTypeTest",
  "$defs": {
    "EmbedValueTypeTest": {
      "properties": {
        "CustomStringType": {
          "type": "string"
        }
      },
      "additionalProperties": false,
      "type": "object",
      "required": [
        "CustomStringType"
      ]
    }
  }
}
```

### Notes

- The tests already have an embedded `MapType` field on several examples, which now appears in the schema output.
- I removed a line that lowercased embedded field names for consistency. If a JSON tag is present on an embedded value type, it will be used for the name. Otherwise the name of the field will be the name of the type.