### PR TITLE
Add format to array items subschema

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -815,6 +815,8 @@ func (t *Schema) arrayKeywords(tags []string) {
 					f, _ := strconv.ParseFloat(val, 64)
 					t.Items.Enum = append(t.Items.Enum, f)
 				}
+			case "format":
+				t.Items.Format = val
 			}
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -477,3 +477,20 @@ func TestSplitOnUnescapedCommas(t *testing.T) {
 		require.Equal(t, test.expected, actual)
 	}
 }
+
+func TestArrayFormat(t *testing.T) {
+	type URIArray struct {
+		TestURIs []string `jsonschema:"type=array,format=uri"`
+	}
+
+	var jsonReflector Reflector
+	schema := jsonReflector.Reflect(&URIArray{})
+
+	URIInterface, found := schema.Definitions["URIArray"].Properties.Get("TestURIs")
+	require.Equal(t, found, true)
+
+	var URIArrayProperties *Schema = URIInterface.(*Schema)
+
+	URIArrayType := URIArrayProperties.Items.Format
+	require.Equal(t, URIArrayType, "uri")
+}


### PR DESCRIPTION
Closes https://github.com/invopop/jsonschema/issues/24

This simply looks for the "format" struct tag when an array is specified and sets the value in the subschema.