### PR TITLE
Add ability to customize $ref value

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -209,6 +209,10 @@ type Reflector struct {
 	// If a json or yaml tag is present, KeyNamer will receive the tag's name as an argument, not the original key name.
 	KeyNamer func(string) string
 
+	// RefMapper allows customizing the path of JSON references, given the name of the type.
+	// By default, "#/$defs/TypeName" will be used.
+	RefMapper func(typeName string) string
+
 	// AdditionalFields allows adding structfields for a given type
 	AdditionalFields func(reflect.Type) []reflect.StructField
 
@@ -587,8 +591,12 @@ func (r *Reflector) addDefinition(definitions Definitions, t reflect.Type, s *Sc
 // refDefinition will provide a schema with a reference to an existing definition.
 func (r *Reflector) refDefinition(_ Definitions, t reflect.Type) *Schema {
 	name := r.typeName(t)
+	ref := "#/$defs/" + name
+	if r.RefMapper != nil {
+		ref = r.RefMapper(name)
+	}
 	return &Schema{
-		Ref: "#/$defs/" + name,
+		Ref: ref,
 	}
 }
 


### PR DESCRIPTION
This pull request adds a new `RefMapper` field to `Reflector` which makes it possible to customize the value of JSON references throughout the schema. This makes it easy to split the schema into multiple files, e.g.:

```go
func writeSchema(v any) error {
	reflector := &jsonschema.Reflector{
		RefMapper: func(typeName string) string {
			return fmt.Sprintf("%s.json", typeName)
		},
	}

	schema := reflector.Reflect(v)
	for typeName, definition := range schema.Definitions {
		f, err := os.OpenFile(fmt.Sprintf("%s.json", typeName), os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
		if err != nil {
			return err
		}
		enc := json.NewEncoder(f)
		enc.SetIndent("", "  ")
		if err := enc.Encode(definition); err != nil {
			return err
		}
	}
}
```