### PR TITLE
Use additionalProperties instead of patternProperties

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -67,10 +67,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "tags": {
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
+          "additionalProperties": {
+            "type": "string"
           },
           "type": "object"
         },

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -67,10 +67,8 @@
       "description": "list of IDs, omitted when empty"
     },
     "tags": {
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
+      "additionalProperties": {
+        "type": "string"
       },
       "type": "object"
     },

--- a/fixtures/go_comments.json
+++ b/fixtures/go_comments.json
@@ -4,10 +4,8 @@
   "$ref": "#/$defs/User",
   "$defs": {
     "NamedPets": {
-      "patternProperties": {
-        ".*": {
-          "$ref": "#/$defs/Pet"
-        }
+      "additionalProperties": {
+        "$ref": "#/$defs/Pet"
       },
       "type": "object",
       "description": "NamedPets is a map of animal names to pets."

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -61,10 +61,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "tags": {
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
+          "additionalProperties": {
+            "type": "string"
           },
           "type": "object"
         },

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -55,10 +55,8 @@
       "description": "list of IDs, omitted when empty"
     },
     "tags": {
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
+      "additionalProperties": {
+        "type": "string"
       },
       "type": "object"
     },

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -57,10 +57,8 @@
       "description": "list of IDs, omitted when empty"
     },
     "tags": {
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
+      "additionalProperties": {
+        "type": "string"
       },
       "type": "object"
     },

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -68,10 +68,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "tags": {
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
+          "additionalProperties": {
+            "type": "string"
           },
           "type": "object"
         },

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -68,10 +68,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "tags": {
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
+          "additionalProperties": {
+            "type": "string"
           },
           "type": "object"
         },

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -70,10 +70,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "tags": {
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
+          "additionalProperties": {
+            "type": "string"
           },
           "type": "object"
         },

--- a/reflect.go
+++ b/reflect.go
@@ -464,9 +464,7 @@ func (r *Reflector) reflectMap(definitions Definitions, t reflect.Type, st *Sche
 		return
 	}
 	if t.Elem().Kind() != reflect.Interface {
-		st.PatternProperties = map[string]*Schema{
-			".*": r.refOrReflectTypeToSchema(definitions, t.Elem()),
-		}
+		st.AdditionalProperties = r.refOrReflectTypeToSchema(definitions, t.Elem())
 	}
 }
 
@@ -491,7 +489,7 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type, s *Sc
 	if r.AssignAnchor {
 		s.Anchor = t.Name()
 	}
-	if !r.AllowAdditionalProperties {
+	if !r.AllowAdditionalProperties && s.AdditionalProperties == nil {
 		s.AdditionalProperties = FalseSchema
 	}
 


### PR DESCRIPTION
This PR changes how Go maps with non-integer keys are represented by jsonschema to use `additionalProperties` instead of `patternProperties`, which is more semantically appropriate and easier to read. (It also happens to be what is supported by redocly-cli at the moment, see https://github.com/Redocly/redocly-cli/issues/792.)