### PR TITLE
Support boolean extra values

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -140,6 +140,11 @@
           ],
           "hello": "world"
         },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
         "color": {
           "type": "string",
           "enum": [

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -140,6 +140,11 @@
       ],
       "hello": "world"
     },
+    "bool_extra": {
+      "type": "string",
+      "isFalse": false,
+      "isTrue": true
+    },
     "color": {
       "type": "string",
       "enum": [

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -134,6 +134,11 @@
           ],
           "hello": "world"
         },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
         "color": {
           "type": "string",
           "enum": [

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -129,6 +129,11 @@
       ],
       "hello": "world"
     },
+    "bool_extra": {
+      "type": "string",
+      "isFalse": false,
+      "isTrue": true
+    },
     "color": {
       "type": "string",
       "enum": [

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -131,6 +131,11 @@
       ],
       "hello": "world"
     },
+    "bool_extra": {
+      "type": "string",
+      "isFalse": false,
+      "isTrue": true
+    },
     "color": {
       "type": "string",
       "enum": [

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -141,6 +141,11 @@
           ],
           "hello": "world"
         },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
         "color": {
           "type": "string",
           "enum": [

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -141,6 +141,11 @@
           ],
           "hello": "world"
         },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
         "color": {
           "type": "string",
           "enum": [

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -143,6 +143,11 @@
           ],
           "hello": "world"
         },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
         "color": {
           "type": "string",
           "enum": [

--- a/reflect.go
+++ b/reflect.go
@@ -874,13 +874,23 @@ func (t *Schema) setExtra(key, val string) {
 			t.Extras[key] = append(existingVal, val)
 		case int:
 			t.Extras[key], _ = strconv.Atoi(val)
+		case bool:
+			t.Extras[key] = (val == "true" || val == "t")
 		}
 	} else {
 		switch key {
 		case "minimum":
 			t.Extras[key], _ = strconv.Atoi(val)
 		default:
-			t.Extras[key] = val
+			var x interface{}
+			if val == "true" {
+				x = true
+			} else if val == "false" {
+				x = false
+			} else {
+				x = val
+			}
+			t.Extras[key] = x
 		}
 	}
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -95,7 +95,8 @@ type TestUser struct {
 	UUID  string `json:"uuid" jsonschema:"format=uuid"`
 
 	// Test for "extras" support
-	Baz string `jsonschema_extras:"foo=bar,hello=world,foo=bar1"`
+	Baz       string `jsonschema_extras:"foo=bar,hello=world,foo=bar1"`
+	BoolExtra string `json:"bool_extra,omitempty" jsonschema_extras:"isTrue=true,isFalse=false"`
 
 	// Tests for simple enum tags
 	Color      string  `json:"color" jsonschema:"enum=red,enum=green,enum=blue"`


### PR DESCRIPTION
* Using the `jsonschema_extras=` property tag will now coerce `true` or `false` strings into boolean properties added to the schema.