### PR TITLE
Allow to set a custom reference root

### DIFF
--- a/fixtures/test_user_reference_root.json
+++ b/fixtures/test_user_reference_root.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$ref": "#/components/schemas/TestUser",
+  "$defs": {
+    "Bytes": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "GrandfatherType": {
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
+    },
+    "MapType": {
+      "type": "object"
+    },
+    "TestUser": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "grand": {
+          "$ref": "#/components/schemas/GrandfatherType"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
+        },
+        "MapType": {
+          "$ref": "#/components/schemas/MapType"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "readOnly": true,
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "options": {
+          "type": "object"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "TestFlagFalse": {
+          "type": "boolean",
+          "default": false
+        },
+        "TestFlagTrue": {
+          "type": "boolean",
+          "default": true
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "photo2": {
+          "$ref": "#/components/schemas/Bytes"
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "type": "integer",
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "uuid": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": [
+            "bar",
+            "bar1"
+          ],
+          "hello": "world"
+        },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
+        "color": {
+          "type": "string",
+          "enum": [
+            "red",
+            "green",
+            "blue"
+          ]
+        },
+        "rank": {
+          "type": "integer",
+          "enum": [
+            1,
+            2,
+            3
+          ]
+        },
+        "mult": {
+          "type": "number",
+          "enum": [
+            1,
+            1.5,
+            2
+          ]
+        },
+        "roles": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ]
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "type": "integer",
+            "enum": [
+              -1,
+              0,
+              1
+            ]
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "type": "number",
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ]
+          },
+          "type": "array"
+        },
+        "anything": true,
+        "raw": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "some_base_property",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "PublicNonExported",
+        "MapType",
+        "name",
+        "password",
+        "TestFlag",
+        "age",
+        "email",
+        "uuid",
+        "Baz",
+        "color",
+        "roles",
+        "raw"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -172,6 +172,12 @@ type Reflector struct {
 	// list of type definitions (`$defs`) will not be included.
 	DoNotReference bool
 
+	// By default definitions are referenced via `#/$defs/[name]`. If the schema
+	// is then embedded in a different context (for example in a OpenAPI spec)
+	// this path might not be correct. ReferenceRoot can be usend to overwrite
+	// the `#/$defs/` path according to the use case.
+	ReferenceRoot string
+
 	// ExpandedStruct when true will include the reflected type's definition in the
 	// root as opposed to a definition with a reference.
 	ExpandedStruct bool
@@ -615,8 +621,12 @@ func (r *Reflector) refDefinition(definitions Definitions, t reflect.Type) *Sche
 	if _, ok := definitions[name]; !ok {
 		return nil
 	}
+	root := "#/$defs/"
+	if r.ReferenceRoot != "" {
+		root = r.ReferenceRoot
+	}
 	return &Schema{
-		Ref: "#/$defs/" + name,
+		Ref: root + name,
 	}
 }
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -331,6 +331,7 @@ func TestSchemaGeneration(t *testing.T) {
 		{&TestUser{}, &Reflector{DoNotReference: true}, "fixtures/no_reference.json"},
 		{&TestUser{}, &Reflector{DoNotReference: true, AssignAnchor: true}, "fixtures/no_reference_anchor.json"},
 		{&RootOneOf{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/oneof.json"},
+		{&TestUser{}, &Reflector{ReferenceRoot: "#/components/schemas/"}, "fixtures/test_user_reference_root.json"},
 		{&CustomTypeField{}, &Reflector{
 			Mapper: func(i reflect.Type) *Schema {
 				if i == reflect.TypeOf(CustomTime{}) {


### PR DESCRIPTION
Currently I am fiddling with invopop/jsonschema and try to generate some OpenAPI definition file. For this I simply use the `jonschema.Reflect()`, iterate over the the `Definitions` and add them to my `#/components/schemas/` (as the spec requires: see https://swagger.io/specification/). An issue with that is that for every schema, the `$ref` fields are referring to "/$defs/...", which is currently hard-coded at https://github.com/invopop/jsonschema/blob/main/reflect.go#L619.

Being able to overwrite the prefix of the `$ref` field would allow to generate _embeddable_ JSON Schema without using something ugly such as bytes.ReplaceAll() to fix the marshaled output. 