### PR TITLE
Fix anonymous ptr to struct inlining

### DIFF
--- a/fixtures/inlining_ptr.json
+++ b/fixtures/inlining_ptr.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/outer-ptr",
+  "properties": {
+    "Foo": {
+      "type": "string"
+    },
+    "Text": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "Foo"
+  ]
+}

--- a/reflect.go
+++ b/reflect.go
@@ -967,7 +967,7 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 		}
 
 		// As per JSON Marshal rules, anonymous pointer to structs are inherited
-		if f.Type.Kind() == reflect.Pointer && f.Type.Elem().Kind() == reflect.Struct {
+		if f.Type.Kind() == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct {
 			return "", true, false, false
 		}
 	}

--- a/reflect.go
+++ b/reflect.go
@@ -965,6 +965,11 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 		if f.Type.Kind() == reflect.Struct {
 			return "", true, false, false
 		}
+
+		// As per JSON Marshal rules, anonymous pointer to structs are inherited
+		if f.Type.Kind() == reflect.Pointer && f.Type.Elem().Kind() == reflect.Struct {
+			return "", true, false, false
+		}
 	}
 
 	// Try to determine the name from the different combos

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -162,6 +162,11 @@ type OuterNamed struct {
 	Inner `json:"inner"`
 }
 
+type OuterPtr struct {
+	*Inner
+	Text `json:",omitempty"`
+}
+
 type Inner struct {
 	Foo string `yaml:"foo"`
 }
@@ -371,6 +376,7 @@ func TestSchemaGeneration(t *testing.T) {
 		{&Outer{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_inheritance.json"},
 		{&OuterNamed{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_embedded.json"},
 		{&OuterNamed{}, &Reflector{ExpandedStruct: true, AssignAnchor: true}, "fixtures/inlining_embedded_anchored.json"},
+		{&OuterPtr{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_ptr.json"},
 		{&MinValue{}, &Reflector{}, "fixtures/schema_with_minimum.json"},
 		{&TestNullable{}, &Reflector{}, "fixtures/nullable.json"},
 		{&GrandfatherType{}, &Reflector{


### PR DESCRIPTION
As can be shown in https://go.dev/play/p/4qEwn5yKzFj, JSON marshal rules also inline anonymous pointer to struct.

This PR implements this feature and adds a test for this.