### PR TITLE
feat(reflect): Add extend method of json schema

### DIFF
--- a/fixtures/anyof_from_jsonschemaext.json
+++ b/fixtures/anyof_from_jsonschemaext.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/root-any-of-extended",
+  "$ref": "#/$defs/RootAnyOfExtended",
+  "$defs": {
+    "RootAnyOfExtended": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "root1": {
+          "enum": [
+            "boulou",
+            "billy"
+          ],
+          "type": "string"
+        },
+        "root2": {
+          "type": "string"
+        },
+        "root3": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "root1": {
+              "const": "boulou"
+            }
+          },
+          "required": [
+            "root2"
+          ]
+        },
+        {
+          "properties": {
+            "root1": {
+              "const": "billy"
+            }
+          },
+          "required": [
+            "root3"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/ifthen_from_jsonschemaext.json
+++ b/fixtures/ifthen_from_jsonschemaext.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/struct-with-ext",
+  "$ref": "#/$defs/StructWithExt",
+  "$defs": {
+    "StructWithExt": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "root1": {
+          "enum": [
+            "child",
+            "root"
+          ],
+          "type": "string"
+        },
+        "root2": {
+          "type": "string"
+        },
+        "inner": {
+          "type": "object",
+          "additionalProperties":false,
+          "properties": {
+            "child1": {
+              "type": "string"
+            }
+          },
+          "required": ["child1"]
+        }
+      },
+      "if": {
+        "properties": {
+          "root1": {
+            "const": "child"
+          }
+        }
+      },
+      "then": {
+        "required": ["inner"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a basic implementation of what could be done with a `JSONSchemaExt(base *Schema)` implementation 