### PR TITLE
feat(reflect): Add method to modify the schema after processing

### DIFF
--- a/fixtures/custom_type_extend.json
+++ b/fixtures/custom_type_extend.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/invopop/jsonschema/schema-post-test",
-  "$ref": "#/$defs/SchemaPostTest",
+  "$id": "https://github.com/invopop/jsonschema/schema-extend-test",
+  "$ref": "#/$defs/SchemaExtendTest",
   "$defs": {
-    "SchemaPostTest": {
+    "SchemaExtendTest": {
       "properties": {
         "LastName": {
           "type": "string",

--- a/fixtures/custom_type_post.json
+++ b/fixtures/custom_type_post.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/schema-post-test",
+  "$ref": "#/$defs/SchemaPostTest",
+  "$defs": {
+    "SchemaPostTest": {
+      "properties": {
+        "LastName": {
+          "type": "string",
+          "description": "some extra words"
+        },
+        "middle_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "LastName"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -110,12 +110,12 @@ type customSchemaImpl interface {
 
 // Function to be run after the schema has been generated.
 // this will let you modify a schema afterwards
-type postSchemaImpl interface {
-	JSONSchemaPost(*Schema)
+type extendSchemaImpl interface {
+	JSONSchemaExtend(*Schema)
 }
 
 var customType = reflect.TypeOf((*customSchemaImpl)(nil)).Elem()
-var postType = reflect.TypeOf((*postSchemaImpl)(nil)).Elem()
+var extendType = reflect.TypeOf((*extendSchemaImpl)(nil)).Elem()
 
 // customSchemaGetFieldDocString
 type customSchemaGetFieldDocString interface {
@@ -402,7 +402,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		panic("unsupported type " + t.String())
 	}
 
-	r.reflectSchemaPost(definitions, t, st)
+	r.reflectSchemaExtend(definitions, t, st)
 
 	// Always try to reference the definition which may have just been created
 	if def := r.refDefinition(definitions, t); def != nil {
@@ -431,11 +431,11 @@ func (r *Reflector) reflectCustomSchema(definitions Definitions, t reflect.Type)
 	return nil
 }
 
-func (r *Reflector) reflectSchemaPost(definitions Definitions, t reflect.Type, s *Schema) *Schema {
-	if t.Implements(postType) {
+func (r *Reflector) reflectSchemaExtend(definitions Definitions, t reflect.Type, s *Schema) *Schema {
+	if t.Implements(extendType) {
 		v := reflect.New(t)
-		o := v.Interface().(postSchemaImpl)
-		o.JSONSchemaPost(s)
+		o := v.Interface().(extendSchemaImpl)
+		o.JSONSchemaExtend(s)
 		if ref := r.refDefinition(definitions, t); ref != nil {
 			return ref
 		}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -306,7 +306,7 @@ type SchemaPostTest struct {
 	SchemaPostTestBase `json:",inline"`
 }
 
-func (SchemaPostTest) JSONSchemaPost(base *Schema) {
+func (SchemaPostTest) JSONSchemaExtend(base *Schema) {
 	base.Properties.Delete("FirstName")
 	base.Properties.Delete("age")
 	val, _ := base.Properties.Get("LastName")

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -310,18 +310,18 @@ type KeyNamed struct {
 	RenamedByComputation int `jsonschema_description:"Description was preserved"`
 }
 
-type SchemaPostTestBase struct {
+type SchemaExtendTestBase struct {
 	FirstName  string `json:"FirstName"`
 	LastName   string `json:"LastName"`
 	Age        uint   `json:"age"`
 	MiddleName string `json:"middle_name,omitempty"`
 }
 
-type SchemaPostTest struct {
-	SchemaPostTestBase `json:",inline"`
+type SchemaExtendTest struct {
+	SchemaExtendTestBase `json:",inline"`
 }
 
-func (SchemaPostTest) JSONSchemaExtend(base *Schema) {
+func (SchemaExtendTest) JSONSchemaExtend(base *Schema) {
 	base.Properties.Delete("FirstName")
 	base.Properties.Delete("age")
 	val, _ := base.Properties.Get("LastName")
@@ -463,7 +463,7 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/keynamed.json"},
 		{MapType{}, &Reflector{}, "fixtures/map_type.json"},
 		{ArrayType{}, &Reflector{}, "fixtures/array_type.json"},
-		{SchemaPostTest{}, &Reflector{}, "fixtures/custom_type_post.json"},
+		{SchemaExtendTest{}, &Reflector{}, "fixtures/custom_type_extend.json"},
 		{Expression{}, &Reflector{}, "fixtures/schema_with_expression.json"},
 	}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -295,6 +295,25 @@ type KeyNamed struct {
 	RenamedByComputation int `jsonschema_description:"Description was preserved"`
 }
 
+type SchemaPostTestBase struct {
+	FirstName  string `json:"FirstName"`
+	LastName   string `json:"LastName"`
+	Age        uint   `json:"age"`
+	MiddleName string `json:"middle_name,omitempty"`
+}
+
+type SchemaPostTest struct {
+	SchemaPostTestBase `json:",inline"`
+}
+
+func (SchemaPostTest) JSONSchemaPost(base *Schema) {
+	base.Properties.Delete("FirstName")
+	base.Properties.Delete("age")
+	val, _ := base.Properties.Get("LastName")
+	(val).(*Schema).Description = "some extra words"
+	base.Required = []string{"LastName"}
+}
+
 func TestReflector(t *testing.T) {
 	r := new(Reflector)
 	s := "http://example.com/schema"
@@ -424,6 +443,7 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/keynamed.json"},
 		{MapType{}, &Reflector{}, "fixtures/map_type.json"},
 		{ArrayType{}, &Reflector{}, "fixtures/array_type.json"},
+		{SchemaPostTest{}, &Reflector{}, "fixtures/custom_type_post.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR is very similar to #52 but moves the call to _after_ the default schema builder has run.

This allows struct properties to be modified easily.