### PR TITLE
Allow for = character in custom property fields

### DIFF
--- a/fixtures/schema_with_expression.json
+++ b/fixtures/schema_with_expression.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/invopop/jsonschema/expression",
+    "$ref": "#/$defs/Expression",
+    "$defs": {
+      "Expression": {
+        "properties": {
+          "value": {
+            "type": "integer",
+            "foo": "bar=='baz'"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "value"
+        ]
+      }
+    }
+  }

--- a/reflect.go
+++ b/reflect.go
@@ -881,7 +881,7 @@ func (t *Schema) arrayKeywords(tags []string) {
 
 func (t *Schema) extraKeywords(tags []string) {
 	for _, tag := range tags {
-		nameValue := strings.Split(tag, "=")
+		nameValue := strings.SplitN(tag, "=", 2)
 		if len(nameValue) == 2 {
 			t.setExtra(nameValue[0], nameValue[1])
 		}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -310,6 +310,10 @@ type KeyNamed struct {
 	RenamedByComputation int `jsonschema_description:"Description was preserved"`
 }
 
+type Expression struct {
+	Value int `json:"value" jsonschema_extras:"foo=bar=='baz'"`
+}
+
 func TestReflector(t *testing.T) {
 	r := new(Reflector)
 	s := "http://example.com/schema"
@@ -440,6 +444,7 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/keynamed.json"},
 		{MapType{}, &Reflector{}, "fixtures/map_type.json"},
 		{ArrayType{}, &Reflector{}, "fixtures/array_type.json"},
+		{Expression{}, &Reflector{}, "fixtures/schema_with_expression.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The code to split custom property fields into field name and value splits the string by '=' and only allows for there to be one '=', effectively splitting the string in two. This prevents the value of the field from having any equals characters. 

This change makes it so the string is split into at most 2 sections, which still checks that an equal sign exists, but allows for the value string to have equals characters.