### PR TITLE
Update reflect.go

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -797,6 +797,9 @@ func (t *Schema) stringKeywords(tags []string) {
 					t.Format = val
 					break
 				}
+			case "deprecated":
+				i, _ := strconv.ParseBool(val)
+				t.Deprecated = i
 			case "readOnly":
 				i, _ := strconv.ParseBool(val)
 				t.ReadOnly = i


### PR DESCRIPTION
Seems deprecated is not handled currently. This PR is to add support for deprecated tag.