### PR TITLE
Added RequiredOverrideFromJSONSchemaTags to be able to override implicit required from omitEmpty 

### DIFF
--- a/fixtures/test_required_override.json
+++ b/fixtures/test_required_override.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-required-struct",
+  "$ref": "#/$defs/TestRequiredStruct",
+  "$defs": {
+    "TestRequiredStruct": {
+      "properties": {
+        "FooOmitEmpty": {
+          "type": "string"
+        },
+        "FooOmitEmptyRequired": {
+          "type": "string"
+        },
+        "FooOmitEmptyRequiredTrue": {
+          "type": "string"
+        },
+        "FooOmitEmptyRequiredFalse": {
+          "type": "string"
+        },
+        "Bar": {
+          "type": "string"
+        },
+        "BarRequired": {
+          "type": "string"
+        },
+        "BarRequiredTrue": {
+          "type": "string"
+        },
+        "BarRequiredFalse": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "FooOmitEmptyRequired",
+        "FooOmitEmptyRequiredTrue",
+        "Bar",
+        "BarRequired",
+        "BarRequiredTrue"
+      ]
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -61,6 +61,18 @@ const (
 	Great
 )
 
+type TestRequiredStruct struct {
+	FooOmitEmpty              string `json:",omitempty"`
+	FooOmitEmptyRequired      string `json:",omitempty" jsonschema:"required"`
+	FooOmitEmptyRequiredTrue  string `json:",omitempty" jsonschema:"required=true"`
+	FooOmitEmptyRequiredFalse string `json:",omitempty" jsonschema:"required=false"`
+
+	Bar              string
+	BarRequired      string `jsonschema:"required"`
+	BarRequiredTrue  string `jsonschema:"required=true"`
+	BarRequiredFalse string `jsonschema:"required=false"`
+}
+
 type TestUser struct {
 	SomeBaseType
 	nonExported
@@ -365,6 +377,7 @@ func TestSchemaGeneration(t *testing.T) {
 		fixture   string
 	}{
 		{&TestUser{}, &Reflector{}, "fixtures/test_user.json"},
+		{&TestRequiredStruct{}, &Reflector{RequiredOverrideFromJSONSchemaTags: true}, "fixtures/test_required_override.json"},
 		{&UserWithAnchor{}, &Reflector{}, "fixtures/user_with_anchor.json"},
 		{&TestUser{}, &Reflector{AssignAnchor: true}, "fixtures/test_user_assign_anchor.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},


### PR DESCRIPTION
Hey,

IMHO using omitempty to figure out if something is required is a sane default which works for most cases.

We now have the usecase that one field in a rather big struct actually can't have omitempty (due to other things using that flag), but still isn't required for our jsonschema.
We _could_ go with RequiredFromJSONSchemaTags, but then we would have to insert tags on every field, which I'd like to avoid.

Using RequiredOverrideFromJSONSchemaTags allows us to set `required=false` on that one field only and call it a day.

I'm aware that the naming is semi optimal and this feels a bit hacky, but seemed like a pragmatic solution.
Any better ideas are more than welcome :)
