### PR TITLE
Check for `yaml:` tags if no `json:` tags found on struct

### DIFF
--- a/fixtures/inlining_embedded.json
+++ b/fixtures/inlining_embedded.json
@@ -4,14 +4,14 @@
   "$defs": {
     "Inner": {
       "properties": {
-        "Foo": {
+        "foo": {
           "type": "string"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "Foo"
+        "foo"
       ]
     }
   },

--- a/fixtures/inlining_embedded_anchored.json
+++ b/fixtures/inlining_embedded_anchored.json
@@ -6,14 +6,14 @@
     "Inner": {
       "$anchor": "Inner",
       "properties": {
-        "Foo": {
+        "foo": {
           "type": "string"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "Foo"
+        "foo"
       ]
     }
   },

--- a/fixtures/inlining_inheritance.json
+++ b/fixtures/inlining_inheritance.json
@@ -8,7 +8,7 @@
     "Text": {
       "type": "string"
     },
-    "Foo": {
+    "foo": {
       "type": "string"
     }
   },
@@ -16,6 +16,6 @@
   "type": "object",
   "required": [
     "TextNamed",
-    "Foo"
+    "foo"
   ]
 }

--- a/fixtures/inlining_ptr.json
+++ b/fixtures/inlining_ptr.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/invopop/jsonschema/outer-ptr",
   "properties": {
-    "Foo": {
+    "foo": {
       "type": "string"
     },
     "Text": {
@@ -12,6 +12,6 @@
   "additionalProperties": false,
   "type": "object",
   "required": [
-    "Foo"
+    "foo"
   ]
 }

--- a/fixtures/user_with_yaml.json
+++ b/fixtures/user_with_yaml.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/user-with-yaml",
+  "$ref": "#/$defs/UserWithYaml",
+  "$defs": {
+    "UserWithYaml": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -989,7 +989,10 @@ func ignoredByJSONSchemaTags(tags []string) bool {
 }
 
 func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool, bool) {
-	jsonTagString, _ := f.Tag.Lookup("json")
+	jsonTagString, ok := f.Tag.Lookup("json")
+	if !ok {
+		jsonTagString, _ = f.Tag.Lookup("yaml")
+	}
 	jsonTags := strings.Split(jsonTagString, ",")
 
 	if ignoredByJSONTags(jsonTags) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -204,6 +204,10 @@ type UserWithAnchor struct {
 	Name string `json:"name" jsonschema:"anchor=Name"`
 }
 
+type UserWithYaml struct {
+	Name string `yaml:"name"`
+}
+
 func (CompactDate) JSONSchema() *Schema {
 	return &Schema{
 		Type:        "string",
@@ -366,6 +370,7 @@ func TestSchemaGeneration(t *testing.T) {
 	}{
 		{&TestUser{}, &Reflector{}, "fixtures/test_user.json"},
 		{&UserWithAnchor{}, &Reflector{}, "fixtures/user_with_anchor.json"},
+		{&UserWithYaml{}, &Reflector{}, "fixtures/user_with_yaml.json"},
 		{&TestUser{}, &Reflector{AssignAnchor: true}, "fixtures/test_user_assign_anchor.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 		{&TestUser{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},


### PR DESCRIPTION
This means that structs that are already confiugured with yaml tags can also use this library to generate a JSON schema, using the same key names and other properties.

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>