### PR TITLE
Add Reflector.Requirer to support custom struct field requiring

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -200,6 +200,10 @@ type Reflector struct {
 	// provided by the reflect package.
 	Namer func(reflect.Type) string
 
+	// Requirer custom the requiring of any struct field, its behaves after the
+	// `json:,omitempty` or `jsonschema:required` parsed.
+	Requirer func(reflect.StructField, bool) bool
+
 	// KeyNamer allows customizing of key names.
 	// The default is to use the key's name as is, or the json tag if present.
 	// If a json tag is present, KeyNamer will receive the tag's name as an argument, not the original key name.
@@ -1004,6 +1008,10 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 	required := requiredFromJSONTags(jsonTags)
 	if r.RequiredFromJSONSchemaTags {
 		required = requiredFromJSONSchemaTags(schemaTags)
+	}
+	// Custom struct field requiring.
+	if r.Requirer != nil {
+		required = r.Requirer(f, required)
 	}
 
 	nullable := nullableFromJSONSchemaTags(schemaTags)


### PR DESCRIPTION
Examples:
```go
package main

import (
	"fmt"
	"reflect"

	"github.com/invopop/jsonschema"
)

type OptionBase struct {
	A int    `json:"a" jsonschema:"required"`
	B string `json:"b" jsonschema:"required"`
}

type OptionChild struct {
	*OptionBase

	C bool `json:"c" jsonschema:"required"`
}

func main() {
	r := jsonschema.Reflector{}
	r.RequiredFromJSONSchemaTags = true
	if s, err := r.Reflect(OptionBase{}).MarshalJSON(); err != nil {
		fmt.Println("failed to marshal OptionBase json schema, err=", err)
	} else {
		// Print OptionBase json schema, all struct fields should be required.
		fmt.Println(string(s))
	}

	// In OptionChild, cancel all requirings of OptionBase struct fields, just keep'C'.
	r.Requirer = func(f reflect.StructField, b bool) bool {
		return f.Name == "C"
	}
	if s, err := r.Reflect(OptionChild{}).MarshalJSON(); err != nil {
		fmt.Println("failed to marshal OptionChild json schema, err=", err)
	} else {
		// Print OptionChild json schema, only struct field 'C' should be required.
		fmt.Println(string(s))
	}
}
```