### PR TITLE
Ensure default floats or ints are converted correctly

### DIFF
--- a/fixtures/number_handling.json
+++ b/fixtures/number_handling.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/number-handler",
+  "$ref": "#/$defs/NumberHandler",
+  "$defs": {
+    "NumberHandler": {
+      "properties": {
+        "int64": {
+          "type": "integer",
+          "default": 12
+        },
+        "float32": {
+          "type": "number",
+          "default": 12.5
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "int64",
+        "float32"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -666,9 +666,9 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	case "string":
 		t.stringKeywords(tags)
 	case "number":
-		t.numbericKeywords(tags)
+		t.numericalKeywords(tags)
 	case "integer":
-		t.numbericKeywords(tags)
+		t.numericalKeywords(tags)
 	case "array":
 		t.arrayKeywords(tags)
 	case "boolean":
@@ -844,8 +844,8 @@ func (t *Schema) stringKeywords(tags []string) {
 	}
 }
 
-// read struct tags for numberic type keyworks
-func (t *Schema) numbericKeywords(tags []string) {
+// read struct tags for numerical type keyworks
+func (t *Schema) numericalKeywords(tags []string) {
 	for _, tag := range tags {
 		nameValue := strings.Split(tag, "=")
 		if len(nameValue) == 2 {
@@ -867,8 +867,8 @@ func (t *Schema) numbericKeywords(tags []string) {
 				b, _ := strconv.ParseBool(val)
 				t.ExclusiveMinimum = b
 			case "default":
-				i, _ := strconv.Atoi(val)
-				t.Default = i
+				n, _ := strconv.ParseFloat(val, 64)
+				t.Default = n
 			case "example":
 				if i, err := strconv.Atoi(val); err == nil {
 					t.Examples = append(t.Examples, i)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -510,6 +510,13 @@ func compareSchemaOutput(t *testing.T, f string, r *Reflector, obj interface{}) 
 	}
 }
 
+func fixtureContains(t *testing.T, f, s string) {
+	t.Helper()
+	b, err := os.ReadFile(f)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), s)
+}
+
 func TestSplitOnUnescapedCommas(t *testing.T) {
 	tests := []struct {
 		strToSplit string
@@ -571,4 +578,16 @@ func TestFieldOneOfRef(t *testing.T) {
 
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/oneof_ref.json", r, &Server{})
+}
+
+func TestNumberHandling(t *testing.T) {
+	type NumberHandler struct {
+		Int64   int64   `json:"int64" jsonschema:"default=12"`
+		Float32 float32 `json:"float32" jsonschema:"default=12.5"`
+	}
+
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/number_handling.json", r, &NumberHandler{})
+	fixtureContains(t, "fixtures/number_handling.json", `"default": 12`)
+	fixtureContains(t, "fixtures/number_handling.json", `"default": 12.5`)
 }


### PR DESCRIPTION
* Fixes #38 
* Uses float parser instead of `Atoi` so that floats are handled correctly.
* Corrected "numberic" typo