### PR TITLE
Use inline comment if no other comment is available

### DIFF
--- a/comment_extractor.go
+++ b/comment_extractor.go
@@ -2,15 +2,14 @@ package jsonschema
 
 import (
 	"fmt"
-	"io/fs"
-	gopath "path"
-	"path/filepath"
-	"strings"
-
 	"go/ast"
 	"go/doc"
 	"go/parser"
 	"go/token"
+	"io/fs"
+	gopath "path"
+	"path/filepath"
+	"strings"
 )
 
 // ExtractGoComments will read all the go files contained in the provided path,
@@ -69,6 +68,9 @@ func ExtractGoComments(base, path string, commentMap map[string]string) error {
 					}
 				case *ast.Field:
 					txt := x.Doc.Text()
+					if txt == "" {
+						txt = x.Comment.Text()
+					}
 					if typ != "" && txt != "" {
 						for _, n := range x.Names {
 							if ast.IsExported(n.String()) {

--- a/comment_extractor.go
+++ b/comment_extractor.go
@@ -2,14 +2,15 @@ package jsonschema
 
 import (
 	"fmt"
-	"go/ast"
-	"go/doc"
-	"go/parser"
-	"go/token"
 	"io/fs"
 	gopath "path"
 	"path/filepath"
 	"strings"
+
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
 )
 
 // ExtractGoComments will read all the go files contained in the provided path,

--- a/examples/nested/nested.go
+++ b/examples/nested/nested.go
@@ -16,6 +16,8 @@ type (
 	// Plant represents the plants the user might have and serves as a test
 	// of structs inside a `type` set.
 	Plant struct {
-		Variant string `json:"variant" jsonschema:"title=Variant"` // This comment will be ignored
+		Variant string `json:"variant" jsonschema:"title=Variant"` // This comment will be used
+		// Multicellular is true if the plant is multicellular
+		Multicellular bool `json:"multicellular,omitempty" jsonschema:"title=Multicellular"` // This comment will be ignored
 	}
 )

--- a/fixtures/go_comments.json
+++ b/fixtures/go_comments.json
@@ -36,7 +36,13 @@
       "properties": {
         "variant": {
           "type": "string",
-          "title": "Variant"
+          "title": "Variant",
+          "description": "This comment will be used"
+        },
+        "multicellular": {
+          "type": "boolean",
+          "title": "Multicellular",
+          "description": "Multicellular is true if the plant is multicellular"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
I needed to generate jsonschema to document some code generated using protoc. 

The protobuf files were already documented like so:
```protobuf
message Event {
    string id = 1;  // the id of the event
    string name = 2; // name of the event
}
```

And protoc generates a struct like so:
```go
type RuleEvent struct {
	state         protoimpl.MessageState
	sizeCache     protoimpl.SizeCache
	unknownFields protoimpl.UnknownFields

	Id   string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`     // the id of the event
	Name string `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"` // name of the event
}
```

The purpose of this pull request is to use the inline comments if the field comment is not available.
If the field comment is available, then the inline comment is still ignored.