### PR TITLE
fix: Unsigned int handling (0 is a valid value)

### DIFF
--- a/fixtures/unsigned_int_handling.json
+++ b/fixtures/unsigned_int_handling.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/unsigned-int-handler",
+  "$ref": "#/$defs/UnsignedIntHandler",
+  "$defs": {
+    "UnsignedIntHandler": {
+      "properties": {
+        "min_len": {
+          "items": {
+            "type": "string",
+            "minLength": 0
+          },
+          "type": "array"
+        },
+        "max_len": {
+          "items": {
+            "type": "string",
+            "maxLength": 0
+          },
+          "type": "array"
+        },
+        "min_items": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "minItems": 0
+        },
+        "max_items": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "maxItems": 0
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "min_len",
+        "max_len",
+        "min_items",
+        "max_items"
+      ]
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -600,3 +600,19 @@ func TestArrayHandling(t *testing.T) {
 	fixtureContains(t, "fixtures/array_handling.json", `"minLength": 2`)
 	fixtureContains(t, "fixtures/array_handling.json", `"minimum": 2.5`)
 }
+
+func TestUnsignedIntHandling(t *testing.T) {
+	type UnsignedIntHandler struct {
+		MinLen   []string `json:"min_len" jsonschema:"minLength=0"`
+		MaxLen   []string `json:"max_len" jsonschema:"maxLength=0"`
+		MinItems []string `json:"min_items" jsonschema:"minItems=0"`
+		MaxItems []string `json:"max_items" jsonschema:"maxItems=0"`
+	}
+
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/unsigned_int_handling.json", r, &UnsignedIntHandler{})
+	fixtureContains(t, "fixtures/unsigned_int_handling.json", `"minLength": 0`)
+	fixtureContains(t, "fixtures/unsigned_int_handling.json", `"maxLength": 0`)
+	fixtureContains(t, "fixtures/unsigned_int_handling.json", `"minItems": 0`)
+	fixtureContains(t, "fixtures/unsigned_int_handling.json", `"maxItems": 0`)
+}


### PR DESCRIPTION
The following validations are fixed or are moved to proper type def at least:
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.3.1
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.3.2
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.1
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.2
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.4
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.5
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.5.1
* https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.5.2
