### PR TITLE
fix: Proper handling of clashing types case

### DIFF
--- a/fixtures/clashing_types.json
+++ b/fixtures/clashing_types.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/invopop/jsonschema/internal/testdata/odd",
+  "$id": "https://github.com/invopop/jsonschema/odd",
   "$ref": "#/$defs/Odd",
   "$defs": {
     "Dummy": {
@@ -43,7 +43,51 @@
         "B"
       ]
     },
+    "GrandfatherType": {
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
+    },
     "Odd": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "grand": {
+          "$ref": "#/$defs/GrandfatherType"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "internal": {
+          "$ref": "#/$defs/Odd_1"
+        },
+        "link": {
+          "$ref": "#/$defs/Odd"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "some_base_property",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "internal",
+        "link"
+      ]
+    },
+    "Odd_1": {
       "properties": {
         "Dummy1": {
           "$ref": "#/$defs/Dummy"

--- a/fixtures/clashing_types.json
+++ b/fixtures/clashing_types.json
@@ -9,7 +9,7 @@
           "type": "string"
         },
         "Dummy": {
-          "$ref": "#/$defs/Dummy_1"
+          "$ref": "#/$defs/Dummy-1"
         }
       },
       "additionalProperties": false,
@@ -19,7 +19,7 @@
         "Dummy"
       ]
     },
-    "Dummy_1": {
+    "Dummy-1": {
       "properties": {
         "A": {
           "type": "string"
@@ -31,7 +31,7 @@
         "A"
       ]
     },
-    "Dummy_2": {
+    "Dummy-2": {
       "properties": {
         "B": {
           "type": "integer"
@@ -70,7 +70,7 @@
           "type": "boolean"
         },
         "internal": {
-          "$ref": "#/$defs/Odd_1"
+          "$ref": "#/$defs/Odd-1"
         },
         "link": {
           "$ref": "#/$defs/Odd"
@@ -87,7 +87,7 @@
         "link"
       ]
     },
-    "Odd_1": {
+    "Odd-1": {
       "properties": {
         "Dummy1": {
           "$ref": "#/$defs/Dummy"
@@ -96,16 +96,16 @@
           "$ref": "#/$defs/Dummy"
         },
         "Dummy2": {
-          "$ref": "#/$defs/Dummy_1"
+          "$ref": "#/$defs/Dummy-1"
         },
         "Dummy2a": {
-          "$ref": "#/$defs/Dummy_1"
+          "$ref": "#/$defs/Dummy-1"
         },
         "Dummy3": {
-          "$ref": "#/$defs/Dummy_2"
+          "$ref": "#/$defs/Dummy-2"
         },
         "Dummy3a": {
-          "$ref": "#/$defs/Dummy_2"
+          "$ref": "#/$defs/Dummy-2"
         }
       },
       "additionalProperties": false,

--- a/fixtures/clashing_types.json
+++ b/fixtures/clashing_types.json
@@ -7,12 +7,16 @@
       "properties": {
         "A": {
           "type": "string"
+        },
+        "Dummy": {
+          "$ref": "#/$defs/Dummy_1"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "A"
+        "A",
+        "Dummy"
       ]
     },
     "Dummy_1": {
@@ -41,22 +45,34 @@
     },
     "Odd": {
       "properties": {
-        "dummy1": {
+        "Dummy1": {
           "$ref": "#/$defs/Dummy"
         },
-        "dummy2": {
+        "Dummy1a": {
+          "$ref": "#/$defs/Dummy"
+        },
+        "Dummy2": {
           "$ref": "#/$defs/Dummy_1"
         },
-        "dummy3": {
+        "Dummy2a": {
+          "$ref": "#/$defs/Dummy_1"
+        },
+        "Dummy3": {
+          "$ref": "#/$defs/Dummy_2"
+        },
+        "Dummy3a": {
           "$ref": "#/$defs/Dummy_2"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "dummy1",
-        "dummy2",
-        "dummy3"
+        "Dummy1",
+        "Dummy1a",
+        "Dummy2",
+        "Dummy2a",
+        "Dummy3",
+        "Dummy3a"
       ]
     }
   }

--- a/fixtures/clashing_types.json
+++ b/fixtures/clashing_types.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/internal/testdata/odd",
+  "$ref": "#/$defs/Odd",
+  "$defs": {
+    "Dummy": {
+      "properties": {
+        "A": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "A"
+      ]
+    },
+    "Dummy_1": {
+      "properties": {
+        "A": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "A"
+      ]
+    },
+    "Dummy_2": {
+      "properties": {
+        "B": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "B"
+      ]
+    },
+    "Odd": {
+      "properties": {
+        "dummy1": {
+          "$ref": "#/$defs/Dummy"
+        },
+        "dummy2": {
+          "$ref": "#/$defs/Dummy_1"
+        },
+        "dummy3": {
+          "$ref": "#/$defs/Dummy_2"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dummy1",
+        "dummy2",
+        "dummy3"
+      ]
+    }
+  }
+}

--- a/fixtures/shadowed_clashing_types.json
+++ b/fixtures/shadowed_clashing_types.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/grandfather-type",
+  "$ref": "#/$defs/GrandfatherType",
+  "$defs": {
+    "GrandfatherType": {
+      "properties": {
+        "odd": {
+          "$ref": "#/$defs/Odd"
+        },
+        "link": {
+          "$ref": "#/$defs/GrandfatherType"
+        },
+        "pkg_link": {
+          "$ref": "#/$defs/GrandfatherType_1"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "odd",
+        "link",
+        "pkg_link"
+      ]
+    },
+    "GrandfatherType_1": {
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
+    },
+    "Odd": {
+      "properties": {
+        "base": {
+          "$ref": "#/$defs/GrandfatherType_1"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "base"
+      ]
+    }
+  }
+}

--- a/fixtures/shadowed_clashing_types.json
+++ b/fixtures/shadowed_clashing_types.json
@@ -12,7 +12,7 @@
           "$ref": "#/$defs/GrandfatherType"
         },
         "pkg_link": {
-          "$ref": "#/$defs/GrandfatherType_1"
+          "$ref": "#/$defs/GrandfatherType-1"
         }
       },
       "additionalProperties": false,
@@ -23,7 +23,7 @@
         "pkg_link"
       ]
     },
-    "GrandfatherType_1": {
+    "GrandfatherType-1": {
       "properties": {
         "family_name": {
           "type": "string"
@@ -38,7 +38,7 @@
     "Odd": {
       "properties": {
         "base": {
-          "$ref": "#/$defs/GrandfatherType_1"
+          "$ref": "#/$defs/GrandfatherType-1"
         }
       },
       "additionalProperties": false,

--- a/internal/testdata/odd.go
+++ b/internal/testdata/odd.go
@@ -1,0 +1,17 @@
+package testdata
+
+import (
+	"github.com/invopop/jsonschema/internal/testdata/types"
+	"github.com/invopop/jsonschema/internal/testdata/types/deeper"
+)
+
+type (
+	Odd struct {
+		Dummy1 types.Dummy  `json:"dummy1"`
+		Dummy2 deeper.Dummy `json:"dummy2"`
+		Dummy3 Dummy        `json:"dummy3"`
+	}
+	Dummy struct {
+		B int
+	}
+)

--- a/internal/testdata/odd.go
+++ b/internal/testdata/odd.go
@@ -7,9 +7,14 @@ import (
 
 type (
 	Odd struct {
-		Dummy1 types.Dummy  `json:"dummy1"`
-		Dummy2 deeper.Dummy `json:"dummy2"`
-		Dummy3 Dummy        `json:"dummy3"`
+		Dummy1  types.Dummy
+		Dummy1a types.Dummy
+
+		Dummy2  deeper.Dummy
+		Dummy2a deeper.Dummy
+
+		Dummy3  Dummy
+		Dummy3a Dummy
 	}
 	Dummy struct {
 		B int

--- a/internal/testdata/types/deeper/dummy.go
+++ b/internal/testdata/types/deeper/dummy.go
@@ -1,0 +1,5 @@
+package deeper
+
+type Dummy struct {
+	A string
+}

--- a/internal/testdata/types/dummy.go
+++ b/internal/testdata/types/dummy.go
@@ -1,0 +1,5 @@
+package types
+
+type Dummy struct {
+	A string
+}

--- a/internal/testdata/types/dummy.go
+++ b/internal/testdata/types/dummy.go
@@ -1,5 +1,8 @@
 package types
 
+import "github.com/invopop/jsonschema/internal/testdata/types/deeper"
+
 type Dummy struct {
-	A string
+	A     string
+	Dummy deeper.Dummy
 }

--- a/reflect.go
+++ b/reflect.go
@@ -573,16 +573,14 @@ func (r *Reflector) lookupComment(t reflect.Type, name string) string {
 
 // addDefinition will append the provided schema. If needed, an ID and anchor will also be added.
 func (r *Reflector) addDefinition(definitions Definitions, t reflect.Type, s *Schema) {
-	name := r.typeName(t)
-	if name == "" {
-		return
-	}
 	// we save both type & pkg info to match against reflected type later
 	s.sourceType = fullyQualifiedTypeName(t)
 
-	_, defName := r.findDef(definitions, t)
-	// either def != nil & we're overwriting, or it's a new one
-	definitions[defName] = s
+	_, name := r.findDef(definitions, t)
+	if name == "" {
+		return
+	}
+	definitions[name] = s
 }
 
 // refDefinition will provide a schema with a reference to an existing definition.
@@ -590,19 +588,15 @@ func (r *Reflector) refDefinition(definitions Definitions, t reflect.Type) *Sche
 	if r.DoNotReference {
 		return nil
 	}
-	name := r.typeName(t)
-	if name == "" {
-		return nil
-	}
 
-	def, defName := r.findDef(definitions, t)
+	def, name := r.findDef(definitions, t)
 	if def == nil {
 		// no entry present in definitions
+		// This is also true if name == "" (~ r.typeName() == "")
 		return nil
 	}
-
 	return &Schema{
-		Ref: "#/$defs/" + defName,
+		Ref: "#/$defs/" + name,
 	}
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -618,7 +618,7 @@ func (r *Reflector) findDef(definitions Definitions, t reflect.Type) (*Schema, s
 		if sameReflectTypes(def._type, t) {
 			return def, defName
 		}
-		defName = name + "_" + strconv.Itoa(idx)
+		defName = name + "-" + strconv.Itoa(idx)
 	}
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -574,7 +574,7 @@ func (r *Reflector) lookupComment(t reflect.Type, name string) string {
 // addDefinition will append the provided schema. If needed, an ID and anchor will also be added.
 func (r *Reflector) addDefinition(definitions Definitions, t reflect.Type, s *Schema) {
 	// we save both type & pkg info to match against reflected type later
-	s.sourceType = fullyQualifiedTypeName(t)
+	s._type = t
 
 	_, name := r.findDef(definitions, t)
 	if name == "" {
@@ -608,7 +608,6 @@ func (r *Reflector) findDef(definitions Definitions, t reflect.Type) (*Schema, s
 	if name == "" {
 		return nil, ""
 	}
-	sourceType := fullyQualifiedTypeName(t)
 
 	defName := name
 	for idx := 1; ; idx++ {
@@ -616,11 +615,19 @@ func (r *Reflector) findDef(definitions Definitions, t reflect.Type) (*Schema, s
 		if !ok {
 			return nil, defName
 		}
-		if def.sourceType == sourceType {
+		if sameReflectTypes(def._type, t) {
 			return def, defName
 		}
 		defName = name + "_" + strconv.Itoa(idx)
 	}
+}
+
+func sameReflectTypes(a, b reflect.Type) bool {
+	if fullyQualifiedTypeName(a) != fullyQualifiedTypeName(b) {
+		return false
+	}
+
+	return a.AssignableTo(b) && b.AssignableTo(a)
 }
 
 func (r *Reflector) lookupID(t reflect.Type) ID {

--- a/reflect.go
+++ b/reflect.go
@@ -594,7 +594,7 @@ func (r *Reflector) addDefinition(definitions Definitions, t reflect.Type, s *Sc
 		def, ok = r.findDef(definitions, defName, typeName, pkgPath)
 	}
 
-	// wither def != nil & we're overwriting, or it's a new one
+	// either def != nil & we're overwriting, or it's a new one
 	definitions[defName] = s
 }
 
@@ -611,12 +611,13 @@ func (r *Reflector) refDefinition(definitions Definitions, t reflect.Type) *Sche
 	typeName, pkgPath := t.Name(), t.PkgPath()
 	def, ok := r.findDef(definitions, name, typeName, pkgPath)
 	if !ok {
+		// no entry even for a bare name
 		return nil
 	}
 
 	idx := 0
 	defName := name
-	for def == nil {
+	for def == nil { // this will result in 0 iterations if def is already found
 		idx++
 		defName = name + "_" + strconv.Itoa(idx)
 		def, ok = r.findDef(definitions, defName, typeName, pkgPath)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -659,6 +659,12 @@ func TestJSONSchemaAlias(t *testing.T) {
 }
 
 func TestClashingTypes(t *testing.T) {
+	type Odd struct {
+		SomeBaseType
+		Internal testdata.Odd `json:"internal"`
+		Link     *Odd         `json:"link"`
+	}
+
 	r := &Reflector{}
-	compareSchemaOutput(t, "fixtures/clashing_types.json", r, &testdata.Odd{})
+	compareSchemaOutput(t, "fixtures/clashing_types.json", r, &Odd{})
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -668,3 +668,22 @@ func TestClashingTypes(t *testing.T) {
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/clashing_types.json", r, &Odd{})
 }
+
+func TestShadowedClashingTypes(t *testing.T) {
+	type (
+		Odd struct {
+			Base GrandfatherType `json:"base"`
+		}
+		GrandfatherTypePtr *GrandfatherType
+	)
+
+	{
+		type GrandfatherType struct {
+			Odd     Odd                `json:"odd"`
+			Link    *GrandfatherType   `json:"link"`
+			PkgLink GrandfatherTypePtr `json:"pkg_link"`
+		}
+		r := &Reflector{}
+		compareSchemaOutput(t, "fixtures/shadowed_clashing_types.json", r, &GrandfatherType{})
+	}
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/invopop/jsonschema/examples"
-
+	"github.com/invopop/jsonschema/internal/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -656,4 +656,9 @@ func TestJSONSchemaAlias(t *testing.T) {
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/schema_alias.json", r, &AliasObjectB{})
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
+}
+
+func TestClashingTypes(t *testing.T) {
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/clashing_types.json", r, &testdata.Odd{})
 }

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"reflect"
 
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
@@ -79,6 +80,9 @@ type Schema struct {
 
 	// Special boolean representation of the Schema - section 4.3.2
 	boolean *bool
+
+	// sourceType is used to define whether the looked-up definition points to the proper type or not
+	sourceType reflect.Type
 }
 
 var (

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"reflect"
 
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
@@ -80,8 +81,8 @@ type Schema struct {
 	// Special boolean representation of the Schema - section 4.3.2
 	boolean *bool
 
-	// sourceType is used to define whether the looked-up definition points to the proper type or not
-	sourceType string
+	// _type is used to define whether the looked-up definition points to the proper type or not
+	_type reflect.Type
 }
 
 var (

--- a/schema.go
+++ b/schema.go
@@ -2,7 +2,6 @@ package jsonschema
 
 import (
 	"encoding/json"
-	"reflect"
 
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
@@ -82,7 +81,7 @@ type Schema struct {
 	boolean *bool
 
 	// sourceType is used to define whether the looked-up definition points to the proper type or not
-	sourceType reflect.Type
+	sourceType string
 }
 
 var (


### PR DESCRIPTION
Instead of #107

This PR aims to properly reference situations when different types (either shadowed ones or originating different packages, but having the same name) are referenced incorrectly (specifically, only the 1st entry is properly handled, other encounters of the same type name blindly reference the 1st definition, even if the types aren't the same).

To achieve this, the following changes were made:
1. An internal `_type` field was added to `jsonschema.Schema` struct
2. When adding new definition to the `jsonschema.Schema.Definitions` map, original `reflect.Type` value is stored in `_type` field
3. When considering a definition to be referenced, no only the type name is taken into account, but also:
   1. package name
   2. whether the types can be assigned to each other
4. If an entry isn't found by the `name` originally suggested (either inferred from type name, or from `jsonschema.Reflector.Namer` result), the code will try to locate a proper entry by adding `-idx` (e.g., `-1`, `-2`, etc.) suffix to the `name` value
