### PR TITLE
feat: Add `NullableFromType` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,19 @@ The resulting schema generated for this struct would look like:
   }
 }
 ```
+
+### Nullability
+
+Nullability in JSON schema is expressed via
+[`oneOf`](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3) choice
+between original schema & `{"type":"null"}`.
+
+By default, only the struct fields that are explicitly annotated with `jsonschema:"nullable"` tag are marked nullable.
+However, when setting `NullableFromType` to `true`, `jsonschema:"nullable"` is ignored &
+the following Go reflect types are marked as nullable instead:
+
+- `reflect.Pointer`
+- `reflect.UnsafePointer`
+- `reflect.Map`
+- `reflect.Slice`
+- `reflect.Interface`

--- a/fixtures/nullable_from_type_disabled.json
+++ b/fixtures/nullable_from_type_disabled.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/nullable-with-odd-fields",
+  "$ref": "#/$defs/NullableWithOddFields",
+  "$defs": {
+    "NullableWithOddFields": {
+      "properties": {
+        "simple_map": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "map_with_nullable_values": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "int_slice": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "pointer_to_int_slice": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "int_slice_with_nullable_values": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "pointer_to_int_slice_with_nullable_values": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "chan": true,
+        "unsafe_pointer": true,
+        "reader": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "simple_map",
+        "map_with_nullable_values",
+        "int_slice",
+        "pointer_to_int_slice",
+        "int_slice_with_nullable_values",
+        "pointer_to_int_slice_with_nullable_values",
+        "chan",
+        "unsafe_pointer",
+        "reader"
+      ]
+    }
+  }
+}

--- a/fixtures/nullable_from_type_enabled.json
+++ b/fixtures/nullable_from_type_enabled.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/nullable-with-odd-fields",
+  "$ref": "#/$defs/NullableWithOddFields",
+  "$defs": {
+    "NullableWithOddFields": {
+      "properties": {
+        "simple_map": {
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "map_with_nullable_values": {
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "int_slice": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pointer_to_int_slice": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "int_slice_with_nullable_values": {
+          "oneOf": [
+            {
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pointer_to_int_slice_with_nullable_values": {
+          "oneOf": [
+            {
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "chan": true,
+        "unsafe_pointer": {
+          "oneOf": [
+            true,
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reader": {
+          "oneOf": [
+            true,
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "simple_map",
+        "map_with_nullable_values",
+        "int_slice",
+        "pointer_to_int_slice",
+        "int_slice_with_nullable_values",
+        "pointer_to_int_slice_with_nullable_values",
+        "chan",
+        "unsafe_pointer",
+        "reader"
+      ]
+    }
+  }
+}

--- a/fixtures/test_user_nullable_from_type.json
+++ b/fixtures/test_user_nullable_from_type.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/test-user",
+  "$ref": "#/$defs/TestUser",
+  "$defs": {
+    "Bytes": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "GrandfatherType": {
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "family_name"
+      ]
+    },
+    "MapType": {
+      "type": "object"
+    },
+    "TestUser": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "grand": {
+          "$ref": "#/$defs/GrandfatherType"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
+        },
+        "MapType": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/MapType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "readOnly": true,
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
+        },
+        "friends": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array",
+              "description": "list of IDs, omitted when empty"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "options": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "TestFlagFalse": {
+          "type": "boolean",
+          "default": false
+        },
+        "TestFlagTrue": {
+          "type": "boolean",
+          "default": true
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "network_address": {
+          "oneOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "photo": {
+          "oneOf": [
+            {
+              "type": "string",
+              "contentEncoding": "base64"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "photo2": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Bytes"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "type": "integer",
+          "maximum": 120,
+          "exclusiveMaximum": 121,
+          "minimum": 18,
+          "exclusiveMinimum": 17
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "uuid": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": [
+            "bar",
+            "bar1"
+          ],
+          "hello": "world"
+        },
+        "bool_extra": {
+          "type": "string",
+          "isFalse": false,
+          "isTrue": true
+        },
+        "color": {
+          "type": "string",
+          "enum": [
+            "red",
+            "green",
+            "blue"
+          ]
+        },
+        "rank": {
+          "type": "integer",
+          "enum": [
+            1,
+            2,
+            3
+          ]
+        },
+        "mult": {
+          "type": "number",
+          "enum": [
+            1.0,
+            1.5,
+            2.0
+          ]
+        },
+        "roles": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string",
+                "enum": [
+                  "admin",
+                  "moderator",
+                  "user"
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "priorities": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "integer",
+                "enum": [
+                  -1,
+                  0,
+                  1
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "offsets": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "number",
+                "enum": [
+                  1.570796,
+                  3.141592,
+                  6.283185
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "anything": {
+          "oneOf": [
+            true,
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "raw": {
+          "oneOf": [
+            true,
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "some_base_property",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "PublicNonExported",
+        "MapType",
+        "name",
+        "password",
+        "TestFlag",
+        "photo",
+        "photo2",
+        "age",
+        "email",
+        "uuid",
+        "Baz",
+        "color",
+        "roles",
+        "raw"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -338,7 +338,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 	case reflect.Map:
 		r.reflectMap(definitions, t, st)
 
-	case reflect.Interface:
+	case reflect.Interface, reflect.Chan, reflect.UnsafePointer:
 		// empty
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/reflect.go
+++ b/reflect.go
@@ -277,7 +277,7 @@ func (r *Reflector) reflectTypeToSchemaWithID(defs Definitions, t reflect.Type) 
 func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) (res *Schema) {
 	defer func() {
 		if r.NullableFromType && isNullable(t.Kind()) {
-			res.makeNullable()
+			res.MakeNullable()
 		}
 	}()
 
@@ -489,7 +489,7 @@ func (r *Reflector) reflectStructFields(st *Schema, definitions Definitions, t r
 	if t.Kind() == reflect.Pointer {
 		r.reflectStructFields(st, definitions, t.Elem())
 		if r.NullableFromType {
-			st.makeNullable()
+			st.MakeNullable()
 		}
 		return
 	}
@@ -534,8 +534,8 @@ func (r *Reflector) reflectStructFields(st *Schema, definitions Definitions, t r
 		}
 
 		unwrapped := property
-		if r.NullableFromType && unwrapped.isNullable() {
-			unwrapped = unwrapped.unwrapNullable()
+		if r.NullableFromType {
+			unwrapped = unwrapped.UnwrapNullable()
 		}
 		unwrapped.structKeywordsFromTags(f, st, name)
 		if unwrapped.Description == "" {
@@ -546,7 +546,7 @@ func (r *Reflector) reflectStructFields(st *Schema, definitions Definitions, t r
 		}
 
 		if nullable && !r.NullableFromType { // we already set the nullability if r.NullableFromType is set
-			property.makeNullable()
+			property.MakeNullable()
 		}
 
 		st.Properties.Set(name, property)
@@ -625,25 +625,6 @@ func (r *Reflector) lookupID(t reflect.Type) ID {
 
 	}
 	return EmptyID
-}
-
-func (t *Schema) makeNullable() {
-	sc := *t
-	*t = Schema{OneOf: []*Schema{&sc, {Type: "null"}}}
-}
-
-func (t *Schema) isNullable() bool {
-	return t.unwrapNullable() != nil
-}
-
-func (t *Schema) unwrapNullable() *Schema {
-	if t.Type != "" {
-		return nil
-	}
-	if len(t.OneOf) != 2 || t.OneOf[1].Type != "null" {
-		return nil
-	}
-	return t.OneOf[0]
 }
 
 func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, propertyName string) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -369,6 +369,7 @@ func TestSchemaGeneration(t *testing.T) {
 		fixture   string
 	}{
 		{&TestUser{}, &Reflector{}, "fixtures/test_user.json"},
+		{&TestUser{}, &Reflector{NullableFromType: true}, "fixtures/test_user_nullable_from_type.json"},
 		{&UserWithAnchor{}, &Reflector{}, "fixtures/user_with_anchor.json"},
 		{&TestUser{}, &Reflector{AssignAnchor: true}, "fixtures/test_user_assign_anchor.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -364,6 +364,27 @@ func TestReflectFromType(t *testing.T) {
 	assert.Empty(t, s.ID)
 }
 
+type NullableWithOddFields struct {
+	SimpleMap             map[string]string  `json:"simple_map"`
+	MapWithNullableValues map[string]*string `json:"map_with_nullable_values"`
+
+	IntSlice                            []int   `json:"int_slice"`
+	PointerToIntSlice                   *[]int  `json:"pointer_to_int_slice"`
+	IntSliceWithNullableValues          []*int  `json:"int_slice_with_nullable_values"`
+	PointerToIntSliceWithNullableValues *[]*int `json:"pointer_to_int_slice_with_nullable_values"`
+
+	Chan          chan int       `json:"chan"`
+	UnsafePointer unsafe.Pointer `json:"unsafe_pointer"`
+	Reader        io.Reader      `json:"reader"`
+}
+
+func TestNullableFromType(t *testing.T) {
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/nullable_from_type_disabled.json", r, &NullableWithOddFields{})
+	r.NullableFromType = true
+	compareSchemaOutput(t, "fixtures/nullable_from_type_enabled.json", r, &NullableWithOddFields{})
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       any
@@ -659,25 +680,4 @@ func TestJSONSchemaAlias(t *testing.T) {
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/schema_alias.json", r, &AliasObjectB{})
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
-}
-
-type NullableWithOddFields struct {
-	SimpleMap             map[string]string  `json:"simple_map"`
-	MapWithNullableValues map[string]*string `json:"map_with_nullable_values"`
-
-	IntSlice                            []int   `json:"int_slice"`
-	PointerToIntSlice                   *[]int  `json:"pointer_to_int_slice"`
-	IntSliceWithNullableValues          []*int  `json:"int_slice_with_nullable_values"`
-	PointerToIntSliceWithNullableValues *[]*int `json:"pointer_to_int_slice_with_nullable_values"`
-
-	Chan          chan int       `json:"chan"`
-	UnsafePointer unsafe.Pointer `json:"unsafe_pointer"`
-	Reader        io.Reader      `json:"reader"`
-}
-
-func TestNullableFromType(t *testing.T) {
-	r := &Reflector{}
-	compareSchemaOutput(t, "fixtures/nullable_from_type_disabled.json", r, &NullableWithOddFields{})
-	r.NullableFromType = true
-	compareSchemaOutput(t, "fixtures/nullable_from_type_enabled.json", r, &NullableWithOddFields{})
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/invopop/jsonschema/examples"
 
@@ -657,4 +659,25 @@ func TestJSONSchemaAlias(t *testing.T) {
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/schema_alias.json", r, &AliasObjectB{})
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
+}
+
+type NullableWithOddFields struct {
+	SimpleMap             map[string]string  `json:"simple_map"`
+	MapWithNullableValues map[string]*string `json:"map_with_nullable_values"`
+
+	IntSlice                            []int   `json:"int_slice"`
+	PointerToIntSlice                   *[]int  `json:"pointer_to_int_slice"`
+	IntSliceWithNullableValues          []*int  `json:"int_slice_with_nullable_values"`
+	PointerToIntSliceWithNullableValues *[]*int `json:"pointer_to_int_slice_with_nullable_values"`
+
+	Chan          chan int       `json:"chan"`
+	UnsafePointer unsafe.Pointer `json:"unsafe_pointer"`
+	Reader        io.Reader      `json:"reader"`
+}
+
+func TestNullableFromType(t *testing.T) {
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/nullable_from_type_disabled.json", r, &NullableWithOddFields{})
+	r.NullableFromType = true
+	compareSchemaOutput(t, "fixtures/nullable_from_type_enabled.json", r, &NullableWithOddFields{})
 }

--- a/schema.go
+++ b/schema.go
@@ -88,6 +88,28 @@ var (
 	FalseSchema = &Schema{boolean: &[]bool{false}[0]}
 )
 
+// MakeNullable will replace the schema that either matches the schema or `null` value:
+// The resulting schema is wrapped via `oneOf` feature.
+//
+//	{"oneOf":[s,{"type":"null"}]}
+func (t *Schema) MakeNullable() {
+	sc := *t
+	*t = Schema{OneOf: []*Schema{&sc, {Type: "null"}}}
+}
+
+// IsNullable will test if the Schema is nullable in terms of MakeNullable
+func (t *Schema) IsNullable() bool {
+	return len(t.OneOf) == 2 && t.OneOf[1].Type == "null"
+}
+
+// UnwrapNullable will return the non-nullable schema part if the schema is nullable.
+func (t *Schema) UnwrapNullable() *Schema {
+	if t.IsNullable() {
+		return t.OneOf[0]
+	}
+	return t
+}
+
 // Definitions hold schema definitions.
 // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.26
 // RFC draft-wright-json-schema-validation-00, section 5.26

--- a/schema.go
+++ b/schema.go
@@ -90,11 +90,14 @@ var (
 
 // MakeNullable will replace the schema that either matches the schema or `null` value:
 // The resulting schema is wrapped via `oneOf` feature.
+// This will be performed if the schema isn't already nullable (as `oneOf` is used).
 //
 //	{"oneOf":[s,{"type":"null"}]}
 func (t *Schema) MakeNullable() {
-	sc := *t
-	*t = Schema{OneOf: []*Schema{&sc, {Type: "null"}}}
+	if !t.IsNullable() {
+		sc := *t
+		*t = Schema{OneOf: []*Schema{&sc, {Type: "null"}}}
+	}
 }
 
 // IsNullable will test if the Schema is nullable in terms of MakeNullable


### PR DESCRIPTION
Instead of https://github.com/invopop/jsonschema/pull/106.

Allows to define property nullability based on the field type instead of the `jsonschema:"nullable"` tag.
Useful when the types included are referenced from 3rd party packages.

Consider the following example:
```go
type TestNullableField struct {
	A *string `json:"a"`
}
```

The following JSON is a perfectly valid value for Go:
```json
{
  "a": null
}
```

The schemas produced for the `TestNullableField` struct are:

<details><summary>Old behavior (`NullableFromType:false`)</summary>
<p>

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$id": "https://github.com/invopop/jsonschema/test-nullable-field",
  "$ref": "#/$defs/TestNullableField",
  "$defs": {
    "TestNullableField": {
      "properties": {
        "a": {
          "type": "string"
        }
      },
      "additionalProperties": false,
      "type": "object",
      "required": [
        "a"
      ]
    }
  }
}
```

</p>
</details>

<details><summary>New behavior (`NullableFromType:true`)</summary>
<p>

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$id": "https://github.com/invopop/jsonschema/test-nullable-field",
  "$ref": "#/$defs/TestNullableField",
  "$defs": {
    "TestNullableField": {
      "properties": {
        "a": {
          "oneOf": [
            {
              "type": "string"
            },
            {
              "type": "null"
            }
          ]
        }
      },
      "additionalProperties": false,
      "type": "object",
      "required": [
        "a"
      ]
    }
  }
}
```

</p>
</details>

In both cases `a` is required, but the old behavior will fail for `{"a":null}` whereas the new one will succeed.