### PR TITLE
fix: Don't limit the explicit format

### DIFF
--- a/fixtures/with_custom_format.json
+++ b/fixtures/with_custom_format.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/with-custom-format",
+  "$ref": "#/$defs/WithCustomFormat",
+  "$defs": {
+    "WithCustomFormat": {
+      "properties": {
+        "dates": {
+          "items": {
+            "type": "string",
+            "format": "date"
+          },
+          "type": "array"
+        },
+        "odds": {
+          "items": {
+            "type": "string",
+            "format": "odd"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dates",
+        "odds"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -768,10 +768,7 @@ func (t *Schema) stringKeywords(tags []string) {
 			case "pattern":
 				t.Pattern = val
 			case "format":
-				switch val {
-				case "date-time", "email", "hostname", "ipv4", "ipv6", "uri", "uuid":
-					t.Format = val
-				}
+				t.Format = val
 			case "readOnly":
 				i, _ := strconv.ParseBool(val)
 				t.ReadOnly = i

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -623,6 +623,18 @@ func TestUnsignedIntHandling(t *testing.T) {
 	fixtureContains(t, "fixtures/unsigned_int_handling.json", `"maxItems": 0`)
 }
 
+func TestJSONSchemaFormat(t *testing.T) {
+	type WithCustomFormat struct {
+		Dates []string `json:"dates" jsonschema:"format=date"`
+		Odds  []string `json:"odds" jsonschema:"format=odd"`
+	}
+
+	r := &Reflector{}
+	compareSchemaOutput(t, "fixtures/with_custom_format.json", r, &WithCustomFormat{})
+	fixtureContains(t, "fixtures/with_custom_format.json", `"format": "date"`)
+	fixtureContains(t, "fixtures/with_custom_format.json", `"format": "odd"`)
+}
+
 type AliasObjectA struct {
 	PropA string `json:"prop_a"`
 }


### PR DESCRIPTION
It's not limited for array items, so top-level ones also should be unlimited.
Fixes #114 