### PR TITLE
fix: Key construction in `ExtractGoComments`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -485,7 +485,7 @@ func TestSchemaGeneration(t *testing.T) {
 func prepareCommentReflector(t *testing.T) *Reflector {
 	t.Helper()
 	r := new(Reflector)
-	err := r.AddGoComments("github.com/invopop/jsonschema", "./examples")
+	err := r.AddGoComments("github.com/invopop/jsonschema/examples", "./examples")
 	require.NoError(t, err, "did not expect error while adding comments")
 	return r
 }


### PR DESCRIPTION
The intended (from README.md) usage of `ExtractGoComments(base, path string, commentMap map[string]string) error` treats the params as following:
* `base` – package import path
* `path` – package location on the filesystem
* `commentMap` output

If we pass `"../"` as `path` param the code will fail to load comments properly because of the `path.Join` used on the unverified input. Moreover, if the `path` is the absolute path, the code will join it with `base` so we end up with keys `base + "/" + absPath` (cleaned in the `path.Clean` func, but still).

This PR fixes the behavior in the following way:
* renaming `path` to `rootPath` for better understanding the semantics & not allowing name clashes in the func
* creating a `root` variable equal to the absolute path of the `rootPath` location
* walking the `root` path
* trimming the `root` prefix of the path prior to joining with the `base` value