### PR TITLE
feat: support const tag

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -43,6 +43,7 @@
         },
         "name": {
           "type": "string",
+          "const": "alex",
           "maxLength": 20,
           "minLength": 1,
           "pattern": ".*",
@@ -80,10 +81,12 @@
         },
         "TestFlagFalse": {
           "type": "boolean",
+          "const": false,
           "default": false
         },
         "TestFlagTrue": {
           "type": "boolean",
+          "const": true,
           "default": true
         },
         "birth_date": {

--- a/fixtures/array_handling.json
+++ b/fixtures/array_handling.json
@@ -11,6 +11,10 @@
             "minLength": 2
           },
           "type": "array",
+          "const": [
+            "foo",
+            "bar"
+          ],
           "default": [
             "qwerty"
           ]

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -43,6 +43,7 @@
     },
     "name": {
       "type": "string",
+      "const": "alex",
       "maxLength": 20,
       "minLength": 1,
       "pattern": ".*",
@@ -80,10 +81,12 @@
     },
     "TestFlagFalse": {
       "type": "boolean",
+      "const": false,
       "default": false
     },
     "TestFlagTrue": {
       "type": "boolean",
+      "const": true,
       "default": true
     },
     "birth_date": {

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -37,6 +37,7 @@
         },
         "name": {
           "type": "string",
+          "const": "alex",
           "maxLength": 20,
           "minLength": 1,
           "pattern": ".*",
@@ -74,10 +75,12 @@
         },
         "TestFlagFalse": {
           "type": "boolean",
+          "const": false,
           "default": false
         },
         "TestFlagTrue": {
           "type": "boolean",
+          "const": true,
           "default": true
         },
         "birth_date": {

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -31,6 +31,7 @@
     },
     "name": {
       "type": "string",
+      "const": "alex",
       "maxLength": 20,
       "minLength": 1,
       "pattern": ".*",
@@ -68,10 +69,12 @@
     },
     "TestFlagFalse": {
       "type": "boolean",
+      "const": false,
       "default": false
     },
     "TestFlagTrue": {
       "type": "boolean",
+      "const": true,
       "default": true
     },
     "birth_date": {

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -33,6 +33,7 @@
     },
     "name": {
       "type": "string",
+      "const": "alex",
       "maxLength": 20,
       "minLength": 1,
       "pattern": ".*",
@@ -70,10 +71,12 @@
     },
     "TestFlagFalse": {
       "type": "boolean",
+      "const": false,
       "default": false
     },
     "TestFlagTrue": {
       "type": "boolean",
+      "const": true,
       "default": true
     },
     "birth_date": {

--- a/fixtures/number_handling.json
+++ b/fixtures/number_handling.json
@@ -7,10 +7,12 @@
       "properties": {
         "int64": {
           "type": "integer",
+          "const": 12,
           "default": 12
         },
         "float32": {
           "type": "number",
+          "const": 12.5,
           "default": 12.5
         }
       },

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -44,6 +44,7 @@
         },
         "name": {
           "type": "string",
+          "const": "alex",
           "maxLength": 20,
           "minLength": 1,
           "pattern": ".*",
@@ -81,10 +82,12 @@
         },
         "TestFlagFalse": {
           "type": "boolean",
+          "const": false,
           "default": false
         },
         "TestFlagTrue": {
           "type": "boolean",
+          "const": true,
           "default": true
         },
         "birth_date": {

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -44,6 +44,7 @@
         },
         "name": {
           "type": "string",
+          "const": "alex",
           "maxLength": 20,
           "minLength": 1,
           "pattern": ".*",
@@ -81,10 +82,12 @@
         },
         "TestFlagFalse": {
           "type": "boolean",
+          "const": false,
           "default": false
         },
         "TestFlagTrue": {
           "type": "boolean",
+          "const": true,
           "default": true
         },
         "birth_date": {

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -46,6 +46,7 @@
         },
         "name": {
           "type": "string",
+          "const": "alex",
           "maxLength": 20,
           "minLength": 1,
           "pattern": ".*",
@@ -83,10 +84,12 @@
         },
         "TestFlagFalse": {
           "type": "boolean",
+          "const": false,
           "default": false
         },
         "TestFlagTrue": {
           "type": "boolean",
+          "const": true,
           "default": true
         },
         "birth_date": {

--- a/reflect.go
+++ b/reflect.go
@@ -744,12 +744,15 @@ func (t *Schema) booleanKeywords(tags []string) {
 			continue
 		}
 		name, val := nameValue[0], nameValue[1]
-		if name == "default" {
-			if val == "true" {
-				t.Default = true
-			} else if val == "false" {
-				t.Default = false
-			}
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			continue
+		}
+		switch name {
+		case "default":
+			t.Default = b
+		case "const":
+			t.Const = b
 		}
 	}
 }
@@ -780,6 +783,8 @@ func (t *Schema) stringKeywords(tags []string) {
 				t.WriteOnly = i
 			case "default":
 				t.Default = val
+			case "const":
+				t.Const = val
 			case "example":
 				t.Examples = append(t.Examples, val)
 			case "enum":
@@ -809,6 +814,10 @@ func (t *Schema) numericalKeywords(tags []string) {
 			case "default":
 				if num, ok := toJSONNumber(val); ok {
 					t.Default = num
+				}
+			case "const":
+				if num, ok := toJSONNumber(val); ok {
+					t.Const = num
 				}
 			case "example":
 				if num, ok := toJSONNumber(val); ok {
@@ -842,6 +851,7 @@ func (t *Schema) numericalKeywords(tags []string) {
 // read struct tags for array type keywords
 func (t *Schema) arrayKeywords(tags []string) {
 	var defaultValues []any
+	var constValues []any
 
 	unprocessed := make([]string, 0, len(tags))
 	for _, tag := range tags {
@@ -857,6 +867,8 @@ func (t *Schema) arrayKeywords(tags []string) {
 				t.UniqueItems = true
 			case "default":
 				defaultValues = append(defaultValues, val)
+			case "const":
+				constValues = append(constValues, val)
 			case "format":
 				t.Items.Format = val
 			case "pattern":
@@ -868,6 +880,9 @@ func (t *Schema) arrayKeywords(tags []string) {
 	}
 	if len(defaultValues) > 0 {
 		t.Default = defaultValues
+	}
+	if len(constValues) > 0 {
+		t.Const = constValues
 	}
 
 	if len(unprocessed) == 0 {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -64,16 +64,16 @@ type TestUser struct {
 	nonExported
 	MapType
 
-	ID       int               `json:"id" jsonschema:"required,minimum=bad,maximum=bad,exclusiveMinimum=bad,exclusiveMaximum=bad,default=bad"`
-	Name     string            `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex,readOnly=true"`
+	ID       int               `json:"id" jsonschema:"required,minimum=bad,maximum=bad,exclusiveMinimum=bad,exclusiveMaximum=bad,default=bad,const=bad"`
+	Name     string            `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex,const=alex,readOnly=true"`
 	Password string            `json:"password" jsonschema:"writeOnly=true"`
 	Friends  []int             `json:"friends,omitempty" jsonschema_description:"list of IDs, omitted when empty"`
 	Tags     map[string]string `json:"tags,omitempty"`
 	Options  map[string]any    `json:"options,omitempty"`
 
 	TestFlag       bool
-	TestFlagFalse  bool `json:",omitempty" jsonschema:"default=false"`
-	TestFlagTrue   bool `json:",omitempty" jsonschema:"default=true"`
+	TestFlagFalse  bool `json:",omitempty" jsonschema:"default=false,const=false"`
+	TestFlagTrue   bool `json:",omitempty" jsonschema:"default=true,const=true"`
 	IgnoredCounter int  `json:"-"`
 
 	// Tests for RFC draft-wright-json-schema-validation-00, section 7.3
@@ -585,19 +585,21 @@ func TestFieldOneOfRef(t *testing.T) {
 
 func TestNumberHandling(t *testing.T) {
 	type NumberHandler struct {
-		Int64   int64   `json:"int64" jsonschema:"default=12"`
-		Float32 float32 `json:"float32" jsonschema:"default=12.5"`
+		Int64   int64   `json:"int64" jsonschema:"default=12,const=12"`
+		Float32 float32 `json:"float32" jsonschema:"default=12.5,const=12.5"`
 	}
 
 	r := &Reflector{}
 	compareSchemaOutput(t, "fixtures/number_handling.json", r, &NumberHandler{})
 	fixtureContains(t, "fixtures/number_handling.json", `"default": 12`)
 	fixtureContains(t, "fixtures/number_handling.json", `"default": 12.5`)
+	fixtureContains(t, "fixtures/number_handling.json", `"const": 12`)
+	fixtureContains(t, "fixtures/number_handling.json", `"const": 12.5`)
 }
 
 func TestArrayHandling(t *testing.T) {
 	type ArrayHandler struct {
-		MinLen []string  `json:"min_len" jsonschema:"minLength=2,default=qwerty"`
+		MinLen []string  `json:"min_len" jsonschema:"minLength=2,default=qwerty,const=foo,const=bar"`
 		MinVal []float64 `json:"min_val" jsonschema:"minimum=2.5"`
 	}
 


### PR DESCRIPTION
Support setting `const` using tag i.e. `jsonschema:"const=foo"`.