### PR TITLE
fix: support json inline tag

### DIFF
--- a/fixtures/inlining_tag.json
+++ b/fixtures/inlining_tag.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/outer-inlined",
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "Foo": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "Foo"
+  ]
+}

--- a/reflect.go
+++ b/reflect.go
@@ -976,6 +976,15 @@ func ignoredByJSONSchemaTags(tags []string) bool {
 	return tags[0] == "-"
 }
 
+func inlinedByJSONTags(tags []string) bool {
+	for _, tag := range tags[1:] {
+		if tag == "inline" {
+			return true
+		}
+	}
+	return false
+}
+
 // toJSONNumber converts string to *json.Number.
 // It'll aso return whether the number is valid.
 func toJSONNumber(s string) (json.Number, bool) {
@@ -1035,6 +1044,11 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 		if f.Type.Kind() == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct {
 			return "", true, false, false
 		}
+	}
+
+	// As per JSON Marshal rules, inline nested structs that have `inline` tag.
+	if inlinedByJSONTags(jsonTags) {
+		return "", true, false, false
 	}
 
 	// Try to determine the name from the different combos

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -176,6 +176,11 @@ type OuterNamed struct {
 	Inner `json:"inner"`
 }
 
+type OuterInlined struct {
+	Text  `json:"text,omitempty"`
+	Inner `json:",inline"`
+}
+
 type OuterPtr struct {
 	*Inner
 	Text `json:",omitempty"`
@@ -419,6 +424,7 @@ func TestSchemaGeneration(t *testing.T) {
 		{&Outer{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_inheritance.json"},
 		{&OuterNamed{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_embedded.json"},
 		{&OuterNamed{}, &Reflector{ExpandedStruct: true, AssignAnchor: true}, "fixtures/inlining_embedded_anchored.json"},
+		{&OuterInlined{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_tag.json"},
 		{&OuterPtr{}, &Reflector{ExpandedStruct: true}, "fixtures/inlining_ptr.json"},
 		{&MinValue{}, &Reflector{}, "fixtures/schema_with_minimum.json"},
 		{&TestNullable{}, &Reflector{}, "fixtures/nullable.json"},


### PR DESCRIPTION
Support JSON `inline` tag.
- Fixes #124 