### PR TITLE
Extract Go comments from "main" package too

### DIFF
--- a/comment_extractor.go
+++ b/comment_extractor.go
@@ -36,9 +36,12 @@ func ExtractGoComments(base, path string, commentMap map[string]string) error {
 			if err != nil {
 				return err
 			}
-			for _, v := range d {
+			for pkg, v := range d {
 				// paths may have multiple packages, like for tests
 				k := gopath.Join(base, path)
+				if pkg == "main" {
+					k = pkg
+				}
 				dict[k] = append(dict[k], v)
 			}
 		}


### PR DESCRIPTION
ExtractGoComments() uses the fully-qualified package path when creating keys in our CommentMap, but we perform lookups in that map using keys constructed using (reflect.Type)PkgPath(). The latter method always returns "main" for types defined in the "main" package, rather than a fully-qualified package path, so those lookups fail. The result is that we never incorporate comments into a schema for types defined in "main".

Update ExtractGoComments() to handle the special case of "main".