### PR TITLE
fix: only override struct description if tag is set

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -609,7 +609,11 @@ func (r *Reflector) lookupID(t reflect.Type) ID {
 }
 
 func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, propertyName string) {
-	t.Description = f.Tag.Get("jsonschema_description")
+	description, ok := f.Tag.Lookup("jsonschema_description")
+	if ok {
+		t.Description = description
+	}
+
 
 	tags := splitOnUnescapedCommas(f.Tag.Get("jsonschema"))
 	tags = t.genericKeywords(tags, parent, propertyName)


### PR DESCRIPTION
I noticed that if you use JSONSchemaExtend to set the description of a nested struct, it would be overwritten by the lookup of `jsonschema_description` on the parent field even if that tag was not provided.

This change makes sure that the tag is actually set, even if it's empty, and only overwrites the description if that is so. This allows the parent to override or remove the description if it wishes.