### PR TITLE
Allow pattern on array items to contain equals sign

### DIFF
--- a/fixtures/equals_in_pattern.json
+++ b/fixtures/equals_in_pattern.json
@@ -12,13 +12,21 @@
         "WithEqualsAndCommas": {
           "type": "string",
           "pattern": "foo,=bar"
+        },
+        "WithEqualsArray": {
+          "items": {
+            "type": "string",
+            "pattern": "foo=bar"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "WithEquals",
-        "WithEqualsAndCommas"
+        "WithEqualsAndCommas",
+        "WithEqualsArray"
       ]
     }
   }

--- a/reflect.go
+++ b/reflect.go
@@ -845,7 +845,7 @@ func (t *Schema) arrayKeywords(tags []string) {
 
 	unprocessed := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		nameValue := strings.Split(tag, "=")
+		nameValue := strings.SplitN(tag, "=", 2)
 		if len(nameValue) == 2 {
 			name, val := nameValue[0], nameValue[1]
 			switch name {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -333,8 +333,9 @@ type Expression struct {
 }
 
 type PatternEqualsTest struct {
-	WithEquals          string `jsonschema:"pattern=foo=bar"`
-	WithEqualsAndCommas string `jsonschema:"pattern=foo\\,=bar"`
+	WithEquals          string   `jsonschema:"pattern=foo=bar"`
+	WithEqualsAndCommas string   `jsonschema:"pattern=foo\\,=bar"`
+	WithEqualsArray     []string `jsonschema:"pattern=foo=bar"`
 }
 
 func TestReflector(t *testing.T) {


### PR DESCRIPTION
Before this fix, array items with a pattern including `=` did not have the pattern propagated to the schema. 