### PR TITLE
Extra KeyNamer-like function that takes in name extraced from tag + origingal go field name

### DIFF
--- a/fixtures/keynamed_with_original_names.json
+++ b/fixtures/keynamed_with_original_names.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/key-namer-with-original-field-named",
+  "$ref": "#/$defs/KeyNamerWithOriginalFieldNamed",
+  "$defs": {
+    "KeyNamerWithOriginalFieldNamed": {
+      "properties": {
+        "ThisWasLeftAsIs": {
+          "type": "string"
+        },
+        "coming_from_json": {
+          "type": "boolean"
+        },
+        "AAA": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ThisWasLeftAsIs",
+        "coming_from_json",
+        "AAA"
+      ]
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -140,6 +140,12 @@ type Reflector struct {
 	// If a json tag is present, KeyNamer will receive the tag's name as an argument, not the original key name.
 	KeyNamer func(string) string
 
+	// KeyNamerWithOriginalFieldName allows customizing of key names.
+	// This is like KeyNamer, except it passes in the name it potentially extracted from the json tag as well as
+	// the original field's name. Has no effect if KeyNamer set.
+	// First argument is the original go field name, second is the one extracted from the json tag
+	KeyNamerWithOriginalFieldName func(string, string) string
+
 	// AdditionalFields allows adding structfields for a given type
 	AdditionalFields func(reflect.Type) []reflect.StructField
 
@@ -1055,6 +1061,8 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool,
 		name = ""
 	} else if r.KeyNamer != nil {
 		name = r.KeyNamer(name)
+	} else if r.KeyNamerWithOriginalFieldName != nil {
+		name = r.KeyNamerWithOriginalFieldName(f.Name, jsonTags[0])
 	}
 
 	return name, false, required, nullable

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -312,6 +312,12 @@ type KeyNamed struct {
 	RenamedByComputation int `jsonschema_description:"Description was preserved"`
 }
 
+type KeyNamerWithOriginalFieldNamed struct {
+	ThisWasLeftAsIs string
+	ComesFromJSON   bool   `json:"coming_from_json"`
+	A               string `json:"bbb"`
+}
+
 type SchemaExtendTestBase struct {
 	FirstName  string `json:"FirstName"`
 	LastName   string `json:"LastName"`
@@ -468,6 +474,24 @@ func TestSchemaGeneration(t *testing.T) {
 				return "unknown case"
 			},
 		}, "fixtures/keynamed.json"},
+		{&KeyNamerWithOriginalFieldNamed{}, &Reflector{
+			KeyNamerWithOriginalFieldName: func(fieldName string, tagName string) string {
+				key := fieldName + ":" + tagName
+				switch key {
+				case "ThisWasLeftAsIs:":
+					return fieldName
+				case "ComesFromJSON:coming_from_json":
+					return tagName
+				case "A:bbb":
+					b := strings.Builder{}
+					for i := 0; i < len(tagName); i++ {
+						b.WriteString(fieldName)
+					}
+					return b.String()
+				}
+				return "unknown case"
+			},
+		}, "fixtures/keynamed_with_original_names.json"},
 		{MapType{}, &Reflector{}, "fixtures/map_type.json"},
 		{ArrayType{}, &Reflector{}, "fixtures/array_type.json"},
 		{SchemaExtendTest{}, &Reflector{}, "fixtures/custom_type_extend.json"},


### PR DESCRIPTION
Over at [lazygit](https://github.com/jesseduffield/lazygit), we use jsonschema to automatically generate our user config schema. We need to populate the schema with default values that we set at runtime [here](https://github.com/jesseduffield/lazygit/blob/67b0db0bd8dbe4d27a8eebb1a8cc85bcb0cb792d/pkg/config/user_config.go#L710). In order to do that, we need to preserve a relationship of the tag name to go struct name, like in this example: `git -> Git`. It would be very convenient if we could somehow hook into jsonschema's reflection process and preserve that relationship.

Earlier, I submitted a [PR](https://github.com/invopop/jsonschema/pull/117) that attached an `OriginalPropertiesMapping` map onto the `Schema` struct that would store the mapping of tag name -> original go field name. This approach works for us, since we can access it on the Schema nodes during our default values population phase, but adds a non jsonschema field to the `Schema` struct.

This PR uses a different approach, where a `KeyNamerWithOriginalFieldName func(string, string) string` can be specified on the `Reflector` struct that gets called in a similar manner to `KeyNamer`. `KeyNamer` takes precedence over `KeyNamerWithOriginalFieldName`.

This approach would allow us to extract the relationship between tag names and go field names while avoiding polluting the `Schema` struct with non jsonschema fields.

Also open to suggestions on how we could extract this relationship without adding anything to the upstream repo, but so far I haven't been able to see an obvious way to do that.