### PR TITLE
Split jsonschema_extras only on unescaped commas

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -126,6 +126,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"

--- a/fixtures/custom_base_schema_id.json
+++ b/fixtures/custom_base_schema_id.json
@@ -115,6 +115,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "Baz": {
           "type": "string",
           "foo": [

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -126,6 +126,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -120,6 +120,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -115,6 +115,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -117,6 +117,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -127,6 +127,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -127,6 +127,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -129,6 +129,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"

--- a/reflect.go
+++ b/reflect.go
@@ -623,7 +623,7 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	case "boolean":
 		t.booleanKeywords(tags)
 	}
-	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
+	extras := splitOnUnescapedCommas(f.Tag.Get("jsonschema_extras"))
 	t.extraKeywords(extras)
 }
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -91,8 +91,9 @@ type TestUser struct {
 	UUID  string `json:"uuid" jsonschema:"format=uuid"`
 
 	// Test for "extras" support
-	Baz       string `jsonschema_extras:"foo=bar,hello=world,foo=bar1"`
-	BoolExtra string `json:"bool_extra,omitempty" jsonschema_extras:"isTrue=true,isFalse=false"`
+	Baz             string `jsonschema_extras:"foo=bar,hello=world,foo=bar1"`
+	BoolExtra       string `json:"bool_extra,omitempty" jsonschema_extras:"isTrue=true,isFalse=false"`
+	ExtraWithComman string `json:"extra_with_commas,omitempty" jsonschema_extras:"foo=bar\\, and also baz,quux=qux"`
 
 	// Tests for simple enum tags
 	Color      string  `json:"color" jsonschema:"enum=red,enum=green,enum=blue"`

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -93,7 +93,7 @@ type TestUser struct {
 	// Test for "extras" support
 	Baz             string `jsonschema_extras:"foo=bar,hello=world,foo=bar1"`
 	BoolExtra       string `json:"bool_extra,omitempty" jsonschema_extras:"isTrue=true,isFalse=false"`
-	ExtraWithComman string `json:"extra_with_commas,omitempty" jsonschema_extras:"foo=bar\\, and also baz,quux=qux"`
+	ExtraWithCommas string `json:"extra_with_commas,omitempty" jsonschema_extras:"foo=bar\\, and also baz,quux=qux"`
 
 	// Tests for simple enum tags
 	Color      string  `json:"color" jsonschema:"enum=red,enum=green,enum=blue"`


### PR DESCRIPTION

This PR splits jsonschema_extras based on unescaped commas, similar to how this works for the jsonschema tag.

Fixes #172 