### PR TITLE
feat: Respect json:",string" for integer fields in generated schema

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -611,12 +611,16 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	tags := splitOnUnescapedCommas(f.Tag.Get("jsonschema"))
 	tags = t.genericKeywords(tags, parent, propertyName)
 
-	// If the json tag has the "string" option, and the type is an integer,
-	// then we should treat the field as a string before applying type-specific
-	// keyword parsing.
+	// The encoding/json ",string" option causes integer, float and boolean
+	// fields to be encoded as JSON strings. Override the reflected type
+	// accordingly before running type-specific keyword parsing so the
+	// generated schema matches the on-the-wire representation.
 	jsonTags := strings.Split(f.Tag.Get("json"), ",")
-	if t.Type == "integer" && tagOptionExists(jsonTags, "string") {
-		t.Type = "string"
+	switch t.Type {
+	case "integer", "number", "boolean":
+		if jsonTagHasOption(jsonTags, "string") {
+			t.Type = "string"
+		}
 	}
 
 	switch t.Type {
@@ -631,7 +635,6 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	case "boolean":
 		t.booleanKeywords(tags)
 	}
-
 	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
 	t.extraKeywords(extras)
 }
@@ -990,7 +993,10 @@ func inlinedByJSONTags(tags []string) bool {
 	return false
 }
 
-func tagOptionExists(tags []string, option string) bool {
+// jsonTagHasOption reports whether the parsed json struct tag contains the
+// given option. The first element of tags is assumed to be the field name, as
+// produced by strings.Split on a raw json tag value, and is skipped.
+func jsonTagHasOption(tags []string, option string) bool {
 	for _, tag := range tags[1:] {
 		if tag == option {
 			return true

--- a/reflect.go
+++ b/reflect.go
@@ -623,6 +623,14 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	case "boolean":
 		t.booleanKeywords(tags)
 	}
+
+	// If the json tag has the "string" option, and the type is an integer,
+	// then we should override the type to be a string.
+	jsonTag := f.Tag.Get("json")
+	if strings.Contains(jsonTag, ",string") && t.Type == "integer" {
+		t.Type = "string"
+	}
+
 	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
 	t.extraKeywords(extras)
 }

--- a/reflect.go
+++ b/reflect.go
@@ -611,6 +611,14 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 	tags := splitOnUnescapedCommas(f.Tag.Get("jsonschema"))
 	tags = t.genericKeywords(tags, parent, propertyName)
 
+	// If the json tag has the "string" option, and the type is an integer,
+	// then we should treat the field as a string before applying type-specific
+	// keyword parsing.
+	jsonTags := strings.Split(f.Tag.Get("json"), ",")
+	if t.Type == "integer" && tagOptionExists(jsonTags, "string") {
+		t.Type = "string"
+	}
+
 	switch t.Type {
 	case "string":
 		t.stringKeywords(tags)
@@ -622,13 +630,6 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 		t.arrayKeywords(tags)
 	case "boolean":
 		t.booleanKeywords(tags)
-	}
-
-	// If the json tag has the "string" option, and the type is an integer,
-	// then we should override the type to be a string.
-	jsonTag := f.Tag.Get("json")
-	if strings.Contains(jsonTag, ",string") && t.Type == "integer" {
-		t.Type = "string"
 	}
 
 	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
@@ -981,6 +982,15 @@ func ignoredByJSONSchemaTags(tags []string) bool {
 func inlinedByJSONTags(tags []string) bool {
 	for _, tag := range tags[1:] {
 		if tag == "inline" {
+			return true
+		}
+	}
+	return false
+}
+
+func tagOptionExists(tags []string, option string) bool {
+	for _, tag := range tags[1:] {
+		if tag == option {
 			return true
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -665,29 +665,51 @@ func TestJSONSchemaAlias(t *testing.T) {
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
 }
 
-func TestIntegerWithJSONStringTag(t *testing.T) {
-	type S struct {
+func TestJSONStringTag(t *testing.T) {
+	type Ints struct {
 		A int `json:"a,string"`
 		B int `json:"b"`
 	}
+	type Floats struct {
+		A float64 `json:"a,string"`
+		B float32 `json:"b,string"`
+		C float64 `json:"c"`
+	}
+	type Bools struct {
+		A bool `json:"a,string"`
+		B bool `json:"b"`
+	}
+
+	cases := []struct {
+		name     string
+		target   any
+		typeName string
+		property string
+		expected string
+	}{
+		{"int with ,string", &Ints{}, "Ints", "a", "string"},
+		{"int plain", &Ints{}, "Ints", "b", "integer"},
+		{"float64 with ,string", &Floats{}, "Floats", "a", "string"},
+		{"float32 with ,string", &Floats{}, "Floats", "b", "string"},
+		{"float64 plain", &Floats{}, "Floats", "c", "number"},
+		{"bool with ,string", &Bools{}, "Bools", "a", "string"},
+		{"bool plain", &Bools{}, "Bools", "b", "boolean"},
+	}
 
 	r := &Reflector{}
-	schema := r.Reflect(&S{})
-	d := schema.Definitions["S"]
-	require.NotNil(t, d)
-	props := d.Properties
-	require.NotNil(t, props)
-
-	pa, found := props.Get("a")
-	require.True(t, found)
-	require.Equal(t, "string", pa.Type)
-
-	pb, found := props.Get("b")
-	require.True(t, found)
-	require.Equal(t, "integer", pb.Type)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			schema := r.Reflect(c.target)
+			d := schema.Definitions[c.typeName]
+			require.NotNil(t, d)
+			p, found := d.Properties.Get(c.property)
+			require.True(t, found)
+			require.Equal(t, c.expected, p.Type)
+		})
+	}
 }
 
-func TestIntegerWithJSONStringTagUsesStringKeywords(t *testing.T) {
+func TestJSONStringTagUsesStringKeywords(t *testing.T) {
 	type S struct {
 		A int `json:"a,string" jsonschema:"minLength=2,maxLength=4,pattern=^[0-9]+$,default=12,enum=12,enum=34"`
 	}
@@ -713,9 +735,9 @@ func TestIntegerWithJSONStringTagUsesStringKeywords(t *testing.T) {
 	require.Empty(t, pa.Maximum)
 }
 
-func TestIntegerWithJSONStringTagRequiresExactOptionMatch(t *testing.T) {
+func TestJSONStringTagRequiresExactOptionMatch(t *testing.T) {
 	type S struct {
-		A int `json:"a,stringly" jsonschema:"minLength=2,minimum=3"`
+		A int `json:"a,stringly" jsonschema:"minLength=2,minimum=3"` //nolint:staticcheck // intentional unknown json option
 	}
 
 	r := &Reflector{}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -664,3 +664,25 @@ func TestJSONSchemaAlias(t *testing.T) {
 	compareSchemaOutput(t, "fixtures/schema_alias.json", r, &AliasObjectB{})
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
 }
+
+func TestIntegerWithJSONStringTag(t *testing.T) {
+	type S struct {
+		A int `json:"a,string"`
+		B int `json:"b"`
+	}
+
+	r := &Reflector{}
+	schema := r.Reflect(&S{})
+	d := schema.Definitions["S"]
+	require.NotNil(t, d)
+	props := d.Properties
+	require.NotNil(t, props)
+
+	pa, found := props.Get("a")
+	require.True(t, found)
+	require.Equal(t, "string", pa.Type)
+
+	pb, found := props.Get("b")
+	require.True(t, found)
+	require.Equal(t, "integer", pb.Type)
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -686,3 +686,48 @@ func TestIntegerWithJSONStringTag(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, "integer", pb.Type)
 }
+
+func TestIntegerWithJSONStringTagUsesStringKeywords(t *testing.T) {
+	type S struct {
+		A int `json:"a,string" jsonschema:"minLength=2,maxLength=4,pattern=^[0-9]+$,default=12,enum=12,enum=34"`
+	}
+
+	r := &Reflector{}
+	schema := r.Reflect(&S{})
+	d := schema.Definitions["S"]
+	require.NotNil(t, d)
+	props := d.Properties
+	require.NotNil(t, props)
+
+	pa, found := props.Get("a")
+	require.True(t, found)
+	require.Equal(t, "string", pa.Type)
+	require.NotNil(t, pa.MinLength)
+	require.NotNil(t, pa.MaxLength)
+	require.EqualValues(t, 2, *pa.MinLength)
+	require.EqualValues(t, 4, *pa.MaxLength)
+	require.Equal(t, "^[0-9]+$", pa.Pattern)
+	require.Equal(t, "12", pa.Default)
+	require.Equal(t, []any{"12", "34"}, pa.Enum)
+	require.Empty(t, pa.Minimum)
+	require.Empty(t, pa.Maximum)
+}
+
+func TestIntegerWithJSONStringTagRequiresExactOptionMatch(t *testing.T) {
+	type S struct {
+		A int `json:"a,stringly" jsonschema:"minLength=2,minimum=3"`
+	}
+
+	r := &Reflector{}
+	schema := r.Reflect(&S{})
+	d := schema.Definitions["S"]
+	require.NotNil(t, d)
+	props := d.Properties
+	require.NotNil(t, props)
+
+	pa, found := props.Get("a")
+	require.True(t, found)
+	require.Equal(t, "integer", pa.Type)
+	require.Nil(t, pa.MinLength)
+	require.Equal(t, json.Number("3"), pa.Minimum)
+}


### PR DESCRIPTION

## Summary
  
Update schema reflection to treat integer fields as `string` when their `json` tag includes the `,string` option, matching `encoding/json` behavior.

## Motivation

Go’s `encoding/json` supports `,string` to encode numbers as strings. Without this, the generated JSON Schema declares `integer` while the payload contains `string`, causing validation issues.