### PR TITLE
Fix nil pointer dereference in ReflectFromType with ExpandedStruct (fix #163)

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -188,8 +188,12 @@ func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 	s.Definitions = definitions
 	bs := r.reflectTypeToSchemaWithID(definitions, t)
 	if r.ExpandedStruct {
-		*s = *definitions[name]
-		delete(definitions, name)
+		if def := definitions[name]; def != nil {
+			*s = *def
+			delete(definitions, name)
+		} else {
+			*s = *bs
+		}
 	} else {
 		*s = *bs
 	}

--- a/reflect_fuzz_test.go
+++ b/reflect_fuzz_test.go
@@ -1,0 +1,60 @@
+package jsonschema
+
+import (
+	"reflect"
+	"testing"
+)
+
+// FuzzReflectFromTypeExpandedStruct exercises ReflectFromType against a
+// fixed pool of reflect.Types while fuzzing the Reflector flag combinations.
+// It guards against regressions of a nil-pointer panic that occurred when
+// ExpandedStruct=true was combined with a non-struct reflect.Type, since
+// only struct types register themselves in the local definitions map.
+func FuzzReflectFromTypeExpandedStruct(f *testing.F) {
+	// Seed byte layout: data[0] selects a type variant, data[1] is a flags
+	// word (bit 3 = ExpandedStruct). Seeds below set ExpandedStruct=true on
+	// types that do NOT register in definitions, which previously triggered
+	// the nil deref.
+	f.Add([]byte{3, 8}) // map[string]any + ExpandedStruct=true
+	f.Add([]byte{4, 8}) // []string       + ExpandedStruct=true
+	f.Add([]byte{5, 8}) // any            + ExpandedStruct=true
+	f.Add([]byte{7, 8}) // enum-tagged field + ExpandedStruct=true
+
+	types := []reflect.Type{
+		reflect.TypeOf(struct{}{}),
+		reflect.TypeOf(struct{ Name string }{}),
+		reflect.TypeOf(struct {
+			A string `json:"a" jsonschema:"required,minLength=1,maxLength=100"`
+			B int    `json:"b,omitempty"`
+		}{}),
+		reflect.TypeOf(map[string]any{}),
+		reflect.TypeOf([]string{}),
+		reflect.TypeOf((*any)(nil)).Elem(),
+		reflect.TypeOf(struct {
+			Self *struct{ X int } `json:"self,omitempty"`
+		}{}),
+		reflect.TypeOf(struct {
+			Tags string `jsonschema:"enum=a,enum=b,enum=c"`
+		}{}.Tags),
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) == 0 {
+			return
+		}
+		idx := int(data[0]) % len(types)
+		typ := types[idx]
+
+		r := &Reflector{}
+		if len(data) > 1 {
+			flags := data[1]
+			r.AllowAdditionalProperties = flags&1 != 0
+			r.RequiredFromJSONSchemaTags = flags&2 != 0
+			r.DoNotReference = flags&4 != 0
+			r.ExpandedStruct = flags&8 != 0
+		}
+
+		// Must not panic regardless of type or flags combination.
+		_ = r.ReflectFromType(typ)
+	})
+}

--- a/reflect_fuzz_test.go
+++ b/reflect_fuzz_test.go
@@ -38,7 +38,7 @@ func FuzzReflectFromTypeExpandedStruct(f *testing.F) {
 		}{}.Tags),
 	}
 
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		if len(data) == 0 {
 			return
 		}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -664,3 +664,33 @@ func TestJSONSchemaAlias(t *testing.T) {
 	compareSchemaOutput(t, "fixtures/schema_alias.json", r, &AliasObjectB{})
 	compareSchemaOutput(t, "fixtures/schema_alias_2.json", r, &AliasObjectC{})
 }
+
+// Regression: ReflectFromType previously panicked with a nil pointer
+// dereference when ExpandedStruct=true was combined with a non-struct
+// reflect.Type (slice, map, interface, enum-tagged struct), because only
+// struct types register themselves in the local definitions map.
+func TestReflectFromTypeExpandedStructNonStruct(t *testing.T) {
+	type enumTagged struct {
+		Tags string `jsonschema:"enum=a,enum=b,enum=c"`
+	}
+
+	cases := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{"slice", reflect.TypeOf([]string{})},
+		{"map", reflect.TypeOf(map[string]any{})},
+		{"interface", reflect.TypeOf((*any)(nil)).Elem()},
+		{"enum_tagged_struct_field", reflect.TypeOf(enumTagged{}.Tags)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Reflector{ExpandedStruct: true}
+			require.NotPanics(t, func() {
+				s := r.ReflectFromType(tc.typ)
+				require.NotNil(t, s)
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes https://github.com/invopop/jsonschema/issues/163

I'm not 100% sure if this is still maintained, but I stumbled uppon what I believe is a bug or at least an unexpected behavior.
The impact for my app was fairly low (dev time), but unexpected.

Example reproducer based on your documentation example:

```golang
package main

import (
	"encoding/json"
	"fmt"
	"reflect"
	"time"

	"github.com/invopop/jsonschema"
)

type SampleUser struct {
	ID int `json:"id"`
}

func main() {
	r := &jsonschema.Reflector{ExpandedStruct: true}

	// The following line works fine (based on the example from the doc)
	// s := r.ReflectFromType(reflect.TypeOf(SampleUser{}))

	// The following line panic (only if ExpandedStruct: true)
	s := r.ReflectFromType(reflect.TypeOf(map[string]interface{}{}))

	data, err := json.MarshalIndent(s, "", "  ")
	if err != nil {
		panic(err.Error())
	}
	fmt.Println(string(data))
}
```


The fix is "just" checking that the key we are deleting exists.

I've added a fuzz test in addition of the regression test, in case we want to discover more bugs in the future (and possibly let agent fix them for you!). The fuzz-test, tests a few more flags combination to have more code coverage. 