### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,4 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.62
+        uses: golangci/golangci-lint-action@v8

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,69 +1,80 @@
+version: "2"
 run:
   tests: true
-  max-same-issues: 50
-
-output:
-  print-issued-lines: false
-
 linters:
   enable:
-    - gocyclo
-    - gocritic
-    - goconst
     - dupl
-    - unconvert
-    - goimports
-    - unused
-    - govet
-    - nakedret
-    - errcheck
-    - revive
-    - ineffassign
     - goconst
+    - gocritic
+    - gocyclo
+    - nakedret
+    - revive
+    - unconvert
     - unparam
-    - gofmt
-
-linters-settings:
-  vet:
-    check-shadowing: true
-    use-installed-packages: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 8
-    min-occurrences: 3
-  gocyclo:
-    min-complexity: 20
-  gocritic:
-    disabled-checks:
-      - ifElseChain
-  gofmt:
-    rewrite-rules:
-      - pattern: "interface{}"
-        replacement: "any"
-      - pattern: "a[b:len(a)]"
-        replacement: "a[b:]"
-
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 8
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: '^(G104|G204):'
+      - path: (.+)\.go$
+        text: Error return value of .(.*\.Help|.*\.MarkFlagRequired|(os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*Print(f|ln|)|os\.(Un)?Setenv). is not checked
+      - path: (.+)\.go$
+        text: 'internal error: no range for'
+      - path: (.+)\.go$
+        text: exported method `.*\.(MarshalJSON|UnmarshalJSON|URN|Payload|GoString|Close|Provides|Requires|ExcludeFromHash|MarshalText|UnmarshalText|Description|Check|Poll|Severity)` should have comment or be unexported
+      - path: (.+)\.go$
+        text: composite literal uses unkeyed fields
+      - path: (.+)\.go$
+        text: declaration of "err" shadows declaration
+      - path: (.+)\.go$
+        text: by other packages, and that stutters
+      - path: (.+)\.go$
+        text: Potential file inclusion via variable
+      - path: (.+)\.go$
+        text: at least one file in a package should have a package comment
+      - path: (.+)\.go$
+        text: bad syntax for struct tag pair
+    paths:
+      - cmd/protopkg/main.go
+      - resources
+      - old
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  max-per-linter: 0
-  max-same: 0
-  exclude-dirs:
-    - resources
-    - old
-  exclude-files:
-    - cmd/protopkg/main.go
-  exclude-use-default: false
-  exclude:
-    # Captured by errcheck.
-    - "^(G104|G204):"
-    # Very commonly not checked.
-    - 'Error return value of .(.*\.Help|.*\.MarkFlagRequired|(os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*Print(f|ln|)|os\.(Un)?Setenv). is not checked'
-    # Weird error only seen on Kochiku...
-    - "internal error: no range for"
-    - 'exported method `.*\.(MarshalJSON|UnmarshalJSON|URN|Payload|GoString|Close|Provides|Requires|ExcludeFromHash|MarshalText|UnmarshalText|Description|Check|Poll|Severity)` should have comment or be unexported'
-    - "composite literal uses unkeyed fields"
-    - 'declaration of "err" shadows declaration'
-    - "by other packages, and that stutters"
-    - "Potential file inclusion via variable"
-    - "at least one file in a package should have a package comment"
-    - "bad syntax for struct tag pair"
+  max-issues-per-linter: 0
+  max-same-issues: 50
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+  exclusions:
+    generated: lax
+    paths:
+      - cmd/protopkg/main.go
+      - resources
+      - old
+      - third_party$
+      - builtin$
+      - examples$

--- a/examples/nested/nested.go
+++ b/examples/nested/nested.go
@@ -1,3 +1,4 @@
+// Package nested contains sample nested types used to exercise schema generation.
 package nested
 
 // Pet defines the user's fury friend.

--- a/examples/user.go
+++ b/examples/user.go
@@ -1,3 +1,4 @@
+// Package examples contains sample types used to exercise schema generation.
 package examples
 
 import (

--- a/reflect.go
+++ b/reflect.go
@@ -742,9 +742,10 @@ func (t *Schema) booleanKeywords(tags []string) {
 		}
 		name, val := nameValue[0], nameValue[1]
 		if name == "default" {
-			if val == "true" {
+			switch val {
+			case "true":
 				t.Default = true
-			} else if val == "false" {
+			case "false":
 				t.Default = false
 			}
 		}
@@ -913,11 +914,12 @@ func (t *Schema) setExtra(key, val string) {
 			t.Extras[key], _ = strconv.Atoi(val)
 		default:
 			var x any
-			if val == "true" {
+			switch val {
+			case "true":
 				x = true
-			} else if val == "false" {
+			case "false":
 				x = false
-			} else {
+			default:
 				x = val
 			}
 			t.Extras[key] = x


### PR DESCRIPTION
## Summary
- Migrate `.golangci.yml` to the v2 configuration format (required by golangci-lint v2; the v1 format no longer loads).
- Bump `golangci/golangci-lint-action` from `@v6` (pinned to `v1.62`) to `@v8`, unpinned so it tracks the action default.
- Fix findings surfaced by the upgrade:
  - Add package comments to `examples/user.go` and `examples/nested/nested.go` (revive `package-comments`).
  - Convert two `if val == "true" { ... } else if val == "false" { ... }` chains in `reflect.go` to tagged switches (staticcheck `QF1003`).

## Test plan
- [x] `golangci-lint run` reports 0 issues locally
- [x] `go test ./...` passes
- [x] Lint workflow passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)