### PR TITLE
Bump minimum Go version to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository is a fork of the original [jsonschema](https://github.com/alecth
 
 This project is still under v0 scheme, as per Go convention, breaking changes are likely. Please pin go modules to version tags or branches, and reach out if you think something can be improved.
 
-Go version >= 1.18 is required as generics are now being used.
+Go version >= 1.24 is now required. We aim for one below the last supported Go version.
 
 ## Example
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/invopop/jsonschema
 
-go 1.18
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/reflect_comments.go
+++ b/reflect_comments.go
@@ -58,72 +58,86 @@ func (r *Reflector) AddGoComments(base, path string, opts ...CommentOption) erro
 
 func (r *Reflector) extractGoComments(base, path string, commentMap map[string]string, opts *commentOptions) error {
 	fset := token.NewFileSet()
-	dict := make(map[string][]*ast.Package)
-	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+	// importPath -> packageName -> files (a directory may hold multiple
+	// packages, e.g. foo and foo_test).
+	dict := make(map[string]map[string][]*ast.File)
+	err := filepath.Walk(path, func(p string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
-			d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
-			if err != nil {
-				return err
-			}
-			for _, v := range d {
-				// paths may have multiple packages, like for tests
-				k := gopath.Join(base, path)
-				dict[k] = append(dict[k], v)
-			}
+		if info.IsDir() || !strings.HasSuffix(p, ".go") {
+			return nil
 		}
+		f, err := parser.ParseFile(fset, p, nil, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+		k := gopath.Join(base, filepath.Dir(p))
+		if dict[k] == nil {
+			dict[k] = make(map[string][]*ast.File)
+		}
+		dict[k][f.Name.Name] = append(dict[k][f.Name.Name], f)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 
-	for pkg, p := range dict {
-		for _, f := range p {
-			gtxt := ""
-			typ := ""
-			ast.Inspect(f, func(n ast.Node) bool {
-				switch x := n.(type) {
-				case *ast.TypeSpec:
-					typ = x.Name.String()
-					if !ast.IsExported(typ) {
-						typ = ""
-					} else {
-						txt := x.Doc.Text()
-						if txt == "" && gtxt != "" {
-							txt = gtxt
-							gtxt = ""
-						}
-						if !opts.fullObjectText {
-							txt = doc.Synopsis(txt)
-						}
-						commentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
-					}
-				case *ast.Field:
-					txt := x.Doc.Text()
-					if txt == "" {
-						txt = x.Comment.Text()
-					}
-					if typ != "" && txt != "" {
-						for _, n := range x.Names {
-							if ast.IsExported(n.String()) {
-								k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
-								commentMap[k] = strings.TrimSpace(txt)
-							}
-						}
-					}
-				case *ast.GenDecl:
-					// remember for the next type
-					gtxt = x.Doc.Text()
-				}
-				return true
-			})
+	for pkg, byName := range dict {
+		for _, files := range byName {
+			docPkg, err := doc.NewFromFiles(fset, files, pkg, doc.AllDecls|doc.PreserveAST)
+			if err != nil {
+				return err
+			}
+			for _, f := range files {
+				collectFileComments(docPkg, f, pkg, commentMap, opts)
+			}
 		}
 	}
 
 	return nil
+}
+
+func collectFileComments(docPkg *doc.Package, f *ast.File, pkg string, commentMap map[string]string, opts *commentOptions) {
+	gtxt := ""
+	typ := ""
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.TypeSpec:
+			typ = x.Name.String()
+			if !ast.IsExported(typ) {
+				typ = ""
+				return true
+			}
+			txt := x.Doc.Text()
+			if txt == "" && gtxt != "" {
+				txt = gtxt
+				gtxt = ""
+			}
+			if !opts.fullObjectText {
+				txt = docPkg.Synopsis(txt)
+			}
+			commentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
+		case *ast.Field:
+			txt := x.Doc.Text()
+			if txt == "" {
+				txt = x.Comment.Text()
+			}
+			if typ == "" || txt == "" {
+				return true
+			}
+			for _, n := range x.Names {
+				if ast.IsExported(n.String()) {
+					k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
+					commentMap[k] = strings.TrimSpace(txt)
+				}
+			}
+		case *ast.GenDecl:
+			// remember for the next type
+			gtxt = x.Doc.Text()
+		}
+		return true
+	})
 }
 
 func (r *Reflector) lookupComment(t reflect.Type, name string) string {

--- a/reflect_comments_test.go
+++ b/reflect_comments_test.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -38,6 +39,36 @@ func prepareCommentReflector(t *testing.T, opts ...CommentOption) *Reflector {
 	err := r.AddGoComments("github.com/invopop/jsonschema", "./examples", opts...)
 	require.NoError(t, err, "did not expect error while adding comments")
 	return r
+}
+
+func TestAddGoCommentsSkipsUnexportedTypes(t *testing.T) {
+	dir := t.TempDir()
+	src := `package sample
+
+// exportedDoc documents the Exported type.
+type Exported struct {
+	// Field is a field comment.
+	Field string
+}
+
+// unexportedDoc documents the unexported type.
+type unexported struct {
+	Field string
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sample.go"), []byte(src), 0o600))
+
+	r := new(Reflector)
+	require.NoError(t, r.AddGoComments("example.com/sample", dir))
+
+	var exportedFound bool
+	for k := range r.CommentMap {
+		require.NotContains(t, k, "unexported", "unexported type must not appear in comment map")
+		if strings.HasSuffix(k, ".Exported") {
+			exportedFound = true
+		}
+	}
+	require.True(t, exportedFound, "exported type should have been picked up")
 }
 
 func prepareCustomCommentReflector(t *testing.T) *Reflector {


### PR DESCRIPTION
## Summary
- Bump `go.mod` from `go 1.18` to `go 1.24` and update the corresponding README note.
- Fix two `staticcheck` `SA1019` deprecations that surface at the new baseline:
  - `ast.Package` (deprecated since Go 1.22): `extractGoComments` now walks files individually with `parser.ParseFile` and groups them as `map[importPath]map[pkgName][]*ast.File`.
  - `doc.Synopsis` (deprecated since Go 1.20): replaced with `doc.Package.Synopsis` via `doc.NewFromFiles(..., doc.PreserveAST)` so the AST stays usable for the existing `ast.Inspect` walk.
- Extract `collectFileComments` to keep `extractGoComments` under the `gocyclo` threshold after the extra grouping level.

Comment-map keys (`<importPath>.<Type>` and `<importPath>.<Type>.<Field>`) and both default/`WithFullComment` synopsis behaviors are preserved.

## Test plan
- [x] `go test ./...` passes (comment extraction covered by `TestCommentsSchemaGeneration` against the existing fixtures)
- [x] `golangci-lint run` reports 0 issues
- [x] CI lint and test workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)