### PR TITLE
fix: nil Reflector.Reflect uses empty Reflector

### DIFF
--- a/nil_reflector_test.go
+++ b/nil_reflector_test.go
@@ -1,0 +1,16 @@
+package jsonschema
+
+import "testing"
+
+func TestNilReflector(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	var r *Reflector
+	s := r.Reflect(struct{ Name string }{})
+	if s == nil {
+		t.Fatal("want schema")
+	}
+}

--- a/reflect.go
+++ b/reflect.go
@@ -172,11 +172,17 @@ type Reflector struct {
 
 // Reflect reflects to Schema from a value.
 func (r *Reflector) Reflect(v any) *Schema {
+	if r == nil {
+		r = &Reflector{}
+	}
 	return r.ReflectFromType(reflect.TypeOf(v))
 }
 
 // ReflectFromType generates root schema
 func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
+	if r == nil {
+		r = &Reflector{}
+	}
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem() // re-assign from pointer
 	}


### PR DESCRIPTION
```go
var r *jsonschema.Reflector
r.Reflect(x) // panic
```

Treat nil like `&Reflector{}`.