### PR TITLE
fix: trim space in ID.Validate

### DIFF
--- a/id.go
+++ b/id.go
@@ -18,7 +18,11 @@ const EmptyID ID = ""
 // This is done by parsing the ID as a URL and checking it has all the
 // relevant parts.
 func (id ID) Validate() error {
-	u, err := url.Parse(id.String())
+	s := strings.TrimSpace(id.String())
+	if s == "" {
+		return errors.New("empty id")
+	}
+	u, err := url.Parse(s)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}

--- a/id_trim_test.go
+++ b/id_trim_test.go
@@ -1,0 +1,13 @@
+package jsonschema
+
+import "testing"
+
+func TestIDValidateTrimSpace(t *testing.T) {
+	id := ID("  https://example.com/schema  ")
+	if err := id.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ID("   ").Validate(); err == nil {
+		t.Fatal("expected empty id error")
+	}
+}


### PR DESCRIPTION
## What

`ID.Validate` trims surrounding space and rejects blank IDs with a clear error.

## Why

Schema IDs from config often include padding.

## Test

- `TestIDValidateTrimSpace`