### PR TITLE
Support IPv4 and IPv6 in net.IP schemas

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -104,7 +104,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         },
         "photo": {
           "type": "string",

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -97,11 +97,9 @@
         "network_address": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],
@@ -135,6 +133,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -151,11 +154,6 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
-        },
-        "extra_with_commas": {
-          "type": "string",
-          "foo": "bar, and also baz",
-          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -95,8 +95,16 @@
           "format": "uri"
         },
         "network_address": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "photo": {
           "type": "string",
@@ -126,11 +134,6 @@
           "type": "string",
           "format": "email"
         },
-        "extra_with_commas": {
-          "type": "string",
-          "foo":  "bar, and also baz",
-          "quux": "qux"
-        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -147,6 +150,11 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
+        },
+        "extra_with_commas": {
+          "type": "string",
+          "foo": "bar, and also baz",
+          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/custom_additional.json
+++ b/fixtures/custom_additional.json
@@ -9,8 +9,16 @@
           "type": "string"
         },
         "ip_addr": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         }
       },
       "additionalProperties": false,

--- a/fixtures/custom_additional.json
+++ b/fixtures/custom_additional.json
@@ -11,11 +11,9 @@
         "ip_addr": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],

--- a/fixtures/custom_additional.json
+++ b/fixtures/custom_additional.json
@@ -18,7 +18,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -95,8 +95,16 @@
       "format": "uri"
     },
     "network_address": {
-      "type": "string",
-      "format": "ipv4"
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "ipv4"
+        },
+        {
+          "type": "string",
+          "format": "ipv6"
+        }
+      ]
     },
     "photo": {
       "type": "string",
@@ -126,11 +134,6 @@
       "type": "string",
       "format": "email"
     },
-    "extra_with_commas": {
-      "type": "string",
-      "foo":  "bar, and also baz",
-      "quux": "qux"
-    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -147,6 +150,11 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
+    },
+    "extra_with_commas": {
+      "type": "string",
+      "foo": "bar, and also baz",
+      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -97,11 +97,9 @@
     "network_address": {
       "anyOf": [
         {
-          "type": "string",
           "format": "ipv4"
         },
         {
-          "type": "string",
           "format": "ipv6"
         }
       ],
@@ -135,6 +133,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -151,11 +154,6 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
-    },
-    "extra_with_commas": {
-      "type": "string",
-      "foo": "bar, and also baz",
-      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -104,7 +104,8 @@
           "type": "string",
           "format": "ipv6"
         }
-      ]
+      ],
+      "type": "string"
     },
     "photo": {
       "type": "string",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -89,8 +89,16 @@
           "format": "uri"
         },
         "network_address": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "photo": {
           "type": "string",
@@ -120,11 +128,6 @@
           "type": "string",
           "format": "email"
         },
-        "extra_with_commas": {
-          "type": "string",
-          "foo":  "bar, and also baz",
-          "quux": "qux"
-        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -141,6 +144,11 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
+        },
+        "extra_with_commas": {
+          "type": "string",
+          "foo": "bar, and also baz",
+          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -91,11 +91,9 @@
         "network_address": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],
@@ -129,6 +127,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -145,11 +148,6 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
-        },
-        "extra_with_commas": {
-          "type": "string",
-          "foo": "bar, and also baz",
-          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -98,7 +98,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         },
         "photo": {
           "type": "string",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -83,8 +83,16 @@
       "format": "uri"
     },
     "network_address": {
-      "type": "string",
-      "format": "ipv4"
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "ipv4"
+        },
+        {
+          "type": "string",
+          "format": "ipv6"
+        }
+      ]
     },
     "photo": {
       "type": "string",
@@ -115,11 +123,6 @@
       "type": "string",
       "format": "email"
     },
-    "extra_with_commas": {
-      "type": "string",
-      "foo":  "bar, and also baz",
-      "quux": "qux"
-    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -136,6 +139,11 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
+    },
+    "extra_with_commas": {
+      "type": "string",
+      "foo": "bar, and also baz",
+      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -85,11 +85,9 @@
     "network_address": {
       "anyOf": [
         {
-          "type": "string",
           "format": "ipv4"
         },
         {
-          "type": "string",
           "format": "ipv6"
         }
       ],
@@ -124,6 +122,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -140,11 +143,6 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
-    },
-    "extra_with_commas": {
-      "type": "string",
-      "foo": "bar, and also baz",
-      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -92,7 +92,8 @@
           "type": "string",
           "format": "ipv6"
         }
-      ]
+      ],
+      "type": "string"
     },
     "photo": {
       "type": "string",

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -94,7 +94,8 @@
           "type": "string",
           "format": "ipv6"
         }
-      ]
+      ],
+      "type": "string"
     },
     "photo": {
       "type": "string",

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -87,11 +87,9 @@
     "network_address": {
       "anyOf": [
         {
-          "type": "string",
           "format": "ipv4"
         },
         {
-          "type": "string",
           "format": "ipv6"
         }
       ],
@@ -126,6 +124,11 @@
       "type": "string",
       "format": "email"
     },
+    "extra_with_commas": {
+      "type": "string",
+      "foo":  "bar, and also baz",
+      "quux": "qux"
+    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -142,11 +145,6 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
-    },
-    "extra_with_commas": {
-      "type": "string",
-      "foo": "bar, and also baz",
-      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -85,8 +85,16 @@
       "format": "uri"
     },
     "network_address": {
-      "type": "string",
-      "format": "ipv4"
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "ipv4"
+        },
+        {
+          "type": "string",
+          "format": "ipv6"
+        }
+      ]
     },
     "photo": {
       "type": "string",
@@ -117,11 +125,6 @@
       "type": "string",
       "format": "email"
     },
-    "extra_with_commas": {
-      "type": "string",
-      "foo":  "bar, and also baz",
-      "quux": "qux"
-    },
     "uuid": {
       "type": "string",
       "format": "uuid"
@@ -138,6 +141,11 @@
       "type": "string",
       "isFalse": false,
       "isTrue": true
+    },
+    "extra_with_commas": {
+      "type": "string",
+      "foo": "bar, and also baz",
+      "quux": "qux"
     },
     "color": {
       "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -96,8 +96,16 @@
           "format": "uri"
         },
         "network_address": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "photo": {
           "type": "string",
@@ -127,11 +135,6 @@
           "type": "string",
           "format": "email"
         },
-        "extra_with_commas": {
-          "type": "string",
-          "foo":  "bar, and also baz",
-          "quux": "qux"
-        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -148,6 +151,11 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
+        },
+        "extra_with_commas": {
+          "type": "string",
+          "foo": "bar, and also baz",
+          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -105,7 +105,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         },
         "photo": {
           "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -98,11 +98,9 @@
         "network_address": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],
@@ -136,6 +134,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -152,11 +155,6 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
-        },
-        "extra_with_commas": {
-          "type": "string",
-          "foo": "bar, and also baz",
-          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -96,8 +96,16 @@
           "format": "uri"
         },
         "network_address": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "photo": {
           "type": "string",
@@ -127,11 +135,6 @@
           "type": "string",
           "format": "email"
         },
-        "extra_with_commas": {
-          "type": "string",
-          "foo":  "bar, and also baz",
-          "quux": "qux"
-        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -148,6 +151,11 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
+        },
+        "extra_with_commas": {
+          "type": "string",
+          "foo": "bar, and also baz",
+          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -105,7 +105,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         },
         "photo": {
           "type": "string",

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -98,11 +98,9 @@
         "network_address": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],
@@ -136,6 +134,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -152,11 +155,6 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
-        },
-        "extra_with_commas": {
-          "type": "string",
-          "foo": "bar, and also baz",
-          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -100,11 +100,9 @@
         "network_address": {
           "anyOf": [
             {
-              "type": "string",
               "format": "ipv4"
             },
             {
-              "type": "string",
               "format": "ipv6"
             }
           ],
@@ -138,6 +136,11 @@
           "type": "string",
           "format": "email"
         },
+        "extra_with_commas": {
+          "type": "string",
+          "foo":  "bar, and also baz",
+          "quux": "qux"
+        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -154,11 +157,6 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
-        },
-        "extra_with_commas": {
-          "type": "string",
-          "foo": "bar, and also baz",
-          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -107,7 +107,8 @@
               "type": "string",
               "format": "ipv6"
             }
-          ]
+          ],
+          "type": "string"
         },
         "photo": {
           "type": "string",

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -98,8 +98,16 @@
           "format": "uri"
         },
         "network_address": {
-          "type": "string",
-          "format": "ipv4"
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "ipv4"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "photo": {
           "type": "string",
@@ -129,11 +137,6 @@
           "type": "string",
           "format": "email"
         },
-        "extra_with_commas": {
-          "type": "string",
-          "foo":  "bar, and also baz",
-          "quux": "qux"
-        },
         "uuid": {
           "type": "string",
           "format": "uuid"
@@ -150,6 +153,11 @@
           "type": "string",
           "isFalse": false,
           "isTrue": true
+        },
+        "extra_with_commas": {
+          "type": "string",
+          "foo": "bar, and also baz",
+          "quux": "qux"
         },
         "color": {
           "type": "string",

--- a/reflect.go
+++ b/reflect.go
@@ -320,6 +320,7 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 	// TODO email RFC section 7.3.2, hostname RFC section 7.3.3, uriref RFC section 7.3.7
 	if t == ipType {
 		// net.IP.UnmarshalText uses net.ParseIP, which accepts ipv4 and ipv6.
+		st.Type = "string"
 		st.AnyOf = []*Schema{
 			{Type: "string", Format: "ipv4"},
 			{Type: "string", Format: "ipv6"},

--- a/reflect.go
+++ b/reflect.go
@@ -319,9 +319,11 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 	// RFC draft-wright-json-schema-validation-00, section 7.3
 	// TODO email RFC section 7.3.2, hostname RFC section 7.3.3, uriref RFC section 7.3.7
 	if t == ipType {
-		// TODO differentiate ipv4 and ipv6 RFC section 7.3.4, 7.3.5
-		st.Type = "string"
-		st.Format = "ipv4"
+		// net.IP.UnmarshalText uses net.ParseIP, which accepts ipv4 and ipv6.
+		st.AnyOf = []*Schema{
+			{Type: "string", Format: "ipv4"},
+			{Type: "string", Format: "ipv6"},
+		}
 		return st
 	}
 

--- a/reflect.go
+++ b/reflect.go
@@ -322,8 +322,8 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		// net.IP.UnmarshalText uses net.ParseIP, which accepts ipv4 and ipv6.
 		st.Type = "string"
 		st.AnyOf = []*Schema{
-			{Type: "string", Format: "ipv4"},
-			{Type: "string", Format: "ipv6"},
+			{Format: "ipv4"},
+			{Format: "ipv6"},
 		}
 		return st
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -787,7 +787,8 @@ func TestJSONStringTagRequiresExactOptionMatch(t *testing.T) {
 
 func TestReflect_NetIPAcceptsIPv4AndIPv6(t *testing.T) {
 	type withIP struct {
-		Addr net.IP `json:"addr"`
+		Addr     net.IP `json:"addr"`
+		Nullable net.IP `json:"nullable" jsonschema:"oneof_type=string;null"`
 	}
 
 	schema := Reflect(&withIP{})
@@ -797,7 +798,13 @@ func TestReflect_NetIPAcceptsIPv4AndIPv6(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, "string", addr.Type)
 	require.Equal(t, []*Schema{
-		{Type: "string", Format: "ipv4"},
-		{Type: "string", Format: "ipv6"},
+		{Format: "ipv4"},
+		{Format: "ipv6"},
 	}, addr.AnyOf)
+
+	nullable, found := definition.Properties.Get("nullable")
+	require.True(t, found)
+	require.Empty(t, nullable.Type)
+	require.Equal(t, []*Schema{{Type: "string"}, {Type: "null"}}, nullable.OneOf)
+	require.Equal(t, []*Schema{{Format: "ipv4"}, {Format: "ipv6"}}, nullable.AnyOf)
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -784,3 +784,18 @@ func TestJSONStringTagRequiresExactOptionMatch(t *testing.T) {
 	require.Nil(t, pa.MinLength)
 	require.Equal(t, json.Number("3"), pa.Minimum)
 }
+
+func TestReflect_NetIPAcceptsIPv4AndIPv6(t *testing.T) {
+	type withIP struct {
+		Addr net.IP `json:"addr"`
+	}
+	data, err := json.Marshal(Reflect(&withIP{}))
+	require.NoError(t, err)
+	s := string(data)
+	if !strings.Contains(s, `"format":"ipv6"`) {
+		t.Fatalf("net.IP schema missing ipv6 (net.ParseIP accepts both): %s", s)
+	}
+	if !strings.Contains(s, `"format":"ipv4"`) {
+		t.Fatalf("net.IP schema missing ipv4: %s", s)
+	}
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -789,13 +789,15 @@ func TestReflect_NetIPAcceptsIPv4AndIPv6(t *testing.T) {
 	type withIP struct {
 		Addr net.IP `json:"addr"`
 	}
-	data, err := json.Marshal(Reflect(&withIP{}))
-	require.NoError(t, err)
-	s := string(data)
-	if !strings.Contains(s, `"format":"ipv6"`) {
-		t.Fatalf("net.IP schema missing ipv6 (net.ParseIP accepts both): %s", s)
-	}
-	if !strings.Contains(s, `"format":"ipv4"`) {
-		t.Fatalf("net.IP schema missing ipv4: %s", s)
-	}
+
+	schema := Reflect(&withIP{})
+	definition := schema.Definitions["withIP"]
+	require.NotNil(t, definition)
+	addr, found := definition.Properties.Get("addr")
+	require.True(t, found)
+	require.Equal(t, "string", addr.Type)
+	require.Equal(t, []*Schema{
+		{Type: "string", Format: "ipv4"},
+		{Type: "string", Format: "ipv6"},
+	}, addr.AnyOf)
 }


### PR DESCRIPTION
fixes #198

net.IP uses ParseIP so ipv6 is valid.
schema was ipv4 only.

emit anyOf ipv4/ipv6. test + fixtures.